### PR TITLE
fix legend not showing in documentation

### DIFF
--- a/mobgap/plotting.py
+++ b/mobgap/plotting.py
@@ -165,10 +165,14 @@ def make_square(ax: plt.Axes, min_max: tuple[float, float], draw_diagonal: bool 
 
 def move_legend_outside(fig: plt.Figure, ax: plt.Axes, **kwargs: dict[str, Any]) -> None:
     """Move the legend from the axes to the figure and place it outside the plot."""
+    handles, labels = ax.get_legend_handles_labels()
     fig.legend(
-        *ax.get_legend_handles_labels(), **{"loc": "center", "bbox_to_anchor": (0.5, -0.05), "ncol": 3, **kwargs}
+        handles,
+        labels,
+        **{"loc": "upper center", "bbox_to_anchor": (0.5, 0.95), "ncol": len(labels), "fontsize": 8, **kwargs},
     )
-    ax.get_legend().remove()
+    for axs in fig.axes:
+        axs.get_legend().remove()
 
 
 def residual_plot(


### PR DESCRIPTION
This pr attempts to solve 2 issues with `mobgap.plotting.move_legend_outside` that is used in correlation and residual plots in [SL documentation](https://mobgap.readthedocs.io/en/latest/auto_revalidation/stride_length/_01_sl_analysis.html#deep-dive-analysis-of-main-algorithms):
1- The final ax legend was meant to be taken outside the subplots, but this isn't showing up.
2- The first ax legend isn't drawn but its frame can be seen under the regression info.

![image](https://github.com/user-attachments/assets/2a3a08c2-eec7-4271-94a9-dda4fd49a393)
