### PR TITLE
Added default version resolution to the validation downloader

### DIFF
--- a/docs/modules/data.rst
+++ b/docs/modules/data.rst
@@ -54,6 +54,13 @@ Load Functions
     load_mobilised_matlab_format
     parse_reference_parameters
 
+Validation Results Data Loader
+------------------------------
+.. autosummary::
+   :toctree: generated/data/validation_results
+   :template: class.rst
+
+    validation_results.ValidationResultLoader
 
 Technical Validation Study (TVS) Data Loader
 --------------------------------------------
@@ -79,6 +86,16 @@ MS Project Dataset
     MsProjectDataset
 
 
+Example Data
+------------
+
+.. autosummary::
+   :toctree: generated/data
+   :template: class.rst
+
+    LabExampleDataset
+
+
 Base Classes
 ++++++++++++
 .. autosummary::
@@ -86,10 +103,6 @@ Base Classes
    :template: class.rst
 
     BaseTVSDataset
-
-
-Example Data
-------------
 
 Dataset Classes
 +++++++++++++++
@@ -114,7 +127,7 @@ Load Functions
     get_all_lab_example_data_paths
 
 
-Mobilise-D v1.0 Pipeline Result Loaders
+Mobilise-D Original Pipeline Result Loaders
 ---------------------------------------
 .. currentmodule:: mobgap.data
 

--- a/mobgap/data/validation_results.py
+++ b/mobgap/data/validation_results.py
@@ -1,20 +1,214 @@
 """Loader for the results of the algorithm validation."""
 
+import sys
+import tempfile
 import warnings
 from pathlib import Path
 from typing import Final, Literal, Optional, Union
 
 import pandas as pd
 import pooch
+import requests
+
+from mobgap import PACKAGE_ROOT
+
+
+def download_file_to_temp(url: str, filename: Optional[str] = None, headers: Optional[dict] = None) -> Path:
+    """
+    Download a file from URL with custom headers and store it in a temporary directory.
+
+    Parameters
+    ----------
+    url : str
+        The URL of the file to download.
+    filename : str, optional
+        Custom filename to use. If None, extracts from URL.
+    headers : dict, optional
+        Custom HTTP headers to include in the request.
+
+    Returns
+    -------
+    pathlib.Path
+        Path object to the downloaded file.
+
+    Raises
+    ------
+    ValueError
+        If URL is invalid.
+    requests.exceptions.HTTPError
+        If HTTP request returns an unsuccessful status code.
+    requests.exceptions.RequestException
+        For other request-related errors.
+    IOError
+        If there's an error writing the file.
+
+    Examples
+    --------
+    >>> file_path = download_file_to_temp("https://example.com/file.pdf")
+    >>> file_path
+    PosixPath('/tmp/file.pdf')
+
+    >>> custom_headers = {"User-Agent": "Mozilla/5.0"}
+    >>> file_path = download_file_to_temp(
+    ...     "https://example.com/data.csv",
+    ...     filename="mydata.csv",
+    ...     headers=custom_headers,
+    ... )
+    """
+    if not url or not isinstance(url, str):
+        raise ValueError("Invalid URL provided")
+
+    try:
+        # Send GET request with custom headers
+        response = requests.get(url, headers=headers, stream=True, timeout=3)
+
+        # Check if the request was successful
+        response.raise_for_status()
+
+        # Create a temporary directory as a Path object
+        temp_dir = Path(tempfile.gettempdir())
+
+        # Use the provided filename or extract from URL
+        if filename is None:
+            filename = url.split("/")[-1]
+            if not filename:  # If URL ends with /, use a default name
+                filename = "downloaded_file"
+
+        # Create the full file path
+        file_path = temp_dir / filename
+
+        # Write the content to a file
+        with file_path.open("wb") as file:
+            for chunk in response.iter_content(chunk_size=8192):
+                if chunk:  # Filter out keep-alive chunks
+                    file.write(chunk)
+    except requests.exceptions.HTTPError:
+        # Re-raise HTTP errors (like 404, 500) as is
+        raise
+    except requests.exceptions.RequestException:
+        # Re-raise network-related errors
+        raise
+    except OSError as e:
+        # Re-raise file writing errors
+        raise OSError(f"Error writing to temporary file: {e!s}") from e
+    else:
+        return file_path
+
+
+def find_best_version() -> str:
+    """Find the best version of the library to use for loading the validation results.
+
+    This is used to determine the version of the library that is currently used.
+    If the library is installed as a dependency, we use the version of the library.
+    If the library is cloned from git, we use the current branch or tag.
+
+    Returns
+    -------
+        The version of the library.
+    """
+    try:
+        import git
+
+        repo = git.Repo(PACKAGE_ROOT.parent)
+    except:  # noqa: E722
+        repo = None
+
+    if repo is not None:
+        if repo.head.is_detached:
+            raise RuntimeError(
+                "The current version of the library is a detached HEAD. "
+                "Please specify a version to load the validation results."
+            )
+        try:
+            tags = [tag.name for tag in repo.tags if tag.commit == repo.head.commit]
+            if tags:
+                return tags[0]  # Return the first tag if multiple exist
+        except:  # noqa: E722
+            pass
+
+        return repo.active_branch.name
+    # If the library is installed as a dependency, we use the version of the library
+    try:
+        import pkg_resources
+
+        return pkg_resources.get_distribution("mobgap").version
+    except Exception as e:
+        raise RuntimeError(
+            "We could neither find the version of the library in the git repository nor in the installed package. "
+            "Specify the version manually."
+        ) from e
+
+
+def check_url_exists(url: str, headers: Optional[dict] = None) -> bool:
+    """Check if a URL exists by sending a HEAD request."""
+    try:
+        response = requests.head(url, timeout=2, headers=headers)
+    except requests.RequestException:
+        return False
+    else:
+        return response.status_code == 200
 
 
 class ValidationResultLoader:
-    """Load the revalidation results either by downloading them or from a local folder."""
+    """Load the revalidation results either by downloading them or from a local folder.
+
+    This is a helper to load the validation results of the algorithms.
+    They are stored in a dedicated git repository (https://github.com/mobilise-d/mobgap_validation).
+    This repository follows the same versioning as the software library.
+    So this means, if you want the validation results for the algorithms of a specific version, you can just find a
+    tag with the same version in the validation repository and use it here.
+    Note, that the validation results might be identical, if no changes were made to the algorithms between two
+    versions.
+    In this case, multiple tags might point to the same results.
+
+    Alternatively, you can load the data from a local folder.
+    This might be helpful during development.
+    For more on that see the Notes section.
+
+    Parameters
+    ----------
+    sub_folder
+        The sub folder within the repository you want to load the results from.
+        The sub folder usually represents a set of experiments or a group of algorithm that was validated.
+        For example, `full_pipeline` is the subfolder for the full pipeline results calulated on the TVS dataset.
+    local_result_path
+        An optional local path to a folder where the results are stored.
+        If specified, the results are loaded from this folder instead of downloading them.
+        The value always takes precedence over the `version` parameter.
+    version
+        A valid git specifier (tag, branch, commit hash) to load the results from.
+        If not specified, the result best fitting to your current version of the library is used.
+        For more information see the Notes section.
+    fallback_version
+        The result version that is used, if the automatically determined version (version == None) is not available.
+
+    Notes
+    -----
+    We determine the version and with that the location where the results are loaded from in the following order:
+
+    1. If `local_result_path` is specified, we use this path and ignore the `version` parameter.
+    2. If `local_result_path` is not specified, and `version` is specified, we use the `version` parameter.
+       Results are then loaded as one request per file to the github api using the specified version as part of the URL.
+    3. If `local_result_path` is not specified and `version` is not specified, we use the following logic to determine
+       the version:
+       - If the library has been installed as a dependency (vs. cloned from git for development), we use the version of
+         the library as tag.
+       - If the library has been cloned from git for development, we use the current we go in order of
+         priority tag > branch.
+         In case of a detached HEAD, we throw an error forcing you to specifying an explicit version that you want to
+         load.
+    4. When a version is automatically determined, we do a test request to the github api to see if the version is
+       available.
+       If not, we use the `fallback_version` parameter to load the results from.
+       If this also fails, you will se the error message
+
+    """
 
     VALIDATION_REPO_DATA = "https://raw.githubusercontent.com/mobilise-d/mobgap_validation/{version}"
     HTTP_HEADERS: Final = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
-        "Chrome/91.0.4472.124 Safari/537.36"
+        # Looks like github rate limits and throttles common user agents to completely unusable rates...
+        # Curl useragent seems to work for now.
+        "User-Agent": "curl/8.12.1"
     }
 
     CONDITION_INDEX_COLS: Final[dict[Literal["free_living", "laboratory"], list[str]]] = {
@@ -37,19 +231,46 @@ class ValidationResultLoader:
         ],
     }
 
-    def __init__(self, sub_folder: str, *, result_path: Optional[Path] = None, version: str = "main") -> None:
+    def __init__(
+        self,
+        sub_folder: str,
+        *,
+        local_result_path: Optional[Union[str, Path]] = None,
+        version: Optional[str] = None,
+        fallback_version: Optional[str] = "main",
+    ) -> None:
         self.sub_folder = sub_folder
-        self.result_path = result_path
+        self.local_result_path = local_result_path
         self.version = version
+        self.fallback_version = fallback_version
 
-        if self.result_path is not None and version != "main":
+        if self.local_result_path is not None and version is not None:
             warnings.warn(
                 "For local loading, we always use the version available in the local folder. "
                 "This means the `version` parameter is ignored.",
                 stacklevel=1,
             )
 
-        if self.result_path is None:
+        if self.local_result_path is None:
+            if version is None:
+                version = find_best_version()
+                # Test request to see if the version is available
+                if not check_url_exists(
+                    f"{self.VALIDATION_REPO_DATA.format(version=version)}/results_file_registry.txt",
+                    headers=self.HTTP_HEADERS,
+                ):
+                    if not self.fallback_version:
+                        raise RuntimeError(
+                            "No version was specified, the automatically determined version is not available and no "
+                            "fallback version was specified."
+                        )
+                    warnings.warn(
+                        f"The automatically determined version {version} is not available. "
+                        f"Using the fallback version {self.fallback_version} instead.",
+                        stacklevel=1,
+                    )
+                    version = self.fallback_version
+            self._resolved_version = version
             self.brian = pooch.create(
                 # Use the default cache folder for the operating system
                 path=pooch.os_cache("mobgap"),
@@ -62,8 +283,8 @@ class ValidationResultLoader:
 
     @property
     def _base_path(self) -> Union[Path, str]:
-        if self.result_path is not None:
-            return self.result_path / self.sub_folder
+        if self.local_result_path is not None:
+            return Path(self.local_result_path) / "results" / self.sub_folder
         return self.sub_folder
 
     @property
@@ -74,15 +295,19 @@ class ValidationResultLoader:
         self, algo_name: str, condition: Literal["free_living", "laboratory"], file_name: str
     ) -> pd.DataFrame:
         """Load any of the results files by name."""
-        if self.result_path is not None:
+        if self.local_result_path is not None:
             return pd.read_csv(
                 self._base_path / condition / algo_name / file_name,
             ).set_index(self.CONDITION_INDEX_COLS[condition])
         if not self.brian.registry:
-            registry = pooch.retrieve(
-                f"{self.VALIDATION_REPO_DATA.format(version=self.version)}/results_file_registry.txt",
-                known_hash=None,
-                downloader=self._downloader,
+            assert self._resolved_version is not None
+            print(f"Downloading registry file for version {self._resolved_version}", file=sys.stderr)
+            # We download the registry direclty and not with pooch resolve, because otherwise poocch cache might
+            # screw us, as it will not download a new version of the file if it is already in the cache.
+            registry = download_file_to_temp(
+                f"{self.VALIDATION_REPO_DATA.format(version=self._resolved_version)}/results_file_registry.txt",
+                filename="results_file_registry.txt",
+                headers=self.HTTP_HEADERS,
             )
             self.brian.load_registry(registry)
         return pd.read_csv(

--- a/poetry.lock
+++ b/poetry.lock
@@ -697,6 +697,42 @@ unicode = ["unicodedata2 (>=15.1.0)"]
 woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+description = "Git Object Database"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf"},
+    {file = "gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571"},
+]
+
+[package.dependencies]
+smmap = ">=3.0.1,<6"
+
+[[package]]
+name = "gitpython"
+version = "3.1.44"
+description = "GitPython is a Python library used to interact with Git repositories"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "GitPython-3.1.44-py3-none-any.whl", hash = "sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110"},
+    {file = "gitpython-3.1.44.tar.gz", hash = "sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269"},
+]
+
+[package.dependencies]
+gitdb = ">=4.0.1,<5"
+
+[package.extras]
+doc = ["sphinx (>=7.1.2,<7.2)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
+test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions"]
+
+[[package]]
 name = "idna"
 version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -2667,6 +2703,19 @@ files = [
 ]
 
 [[package]]
+name = "smmap"
+version = "5.0.2"
+description = "A pure Python implementation of a sliding window memory map manager"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e"},
+    {file = "smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5"},
+]
+
+[[package]]
 name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
@@ -3244,4 +3293,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.13"
-content-hash = "563885cf9caa68f73618f779ad1df3c1a57c422168484ee7107f7cb57edbdaed"
+content-hash = "1491a827b0ee7c1dc21a4cb152634225506c165f5b01b57e1b7aa6105878cbcd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ myst-parser = "^2.0.0"
 ipykernel = "^6.25.1"
 numpydoc = "^1.6.0"
 ipympl = "^0.9.4"
+gitpython = "^3.1.44"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/revalidation/cadence/_01_cadence_analysis.py
+++ b/revalidation/cadence/_01_cadence_analysis.py
@@ -40,7 +40,6 @@ algorithms = {
 #
 # The file download will print a couple log information, which can usually be ignored.
 # You can also change the `version` parameter to load a different version of the data.
-from pathlib import Path
 
 import pandas as pd
 from mobgap.data.validation_results import ValidationResultLoader
@@ -70,14 +69,8 @@ def format_loaded_results(
     return formatted
 
 
-local_data_path = (
-    Path(get_env_var("MOBGAP_VALIDATION_DATA_PATH")) / "results"
-    if int(get_env_var("MOBGAP_VALIDATION_USE_LOCAL_DATA", 0))
-    else None
-)
-loader = ValidationResultLoader(
-    "cad", result_path=local_data_path, version="main"
-)
+local_data_path = get_env_var("MOBGAP_VALIDATION_DATA_PATH", None)
+loader = ValidationResultLoader("cad", local_result_path=local_data_path)
 
 
 free_living_index_cols = [

--- a/revalidation/full_pipeline/_01_pipeline_analysis.py
+++ b/revalidation/full_pipeline/_01_pipeline_analysis.py
@@ -45,7 +45,6 @@ algorithms = {
 #
 # The file download will print a couple log information, which can usually be ignored.
 # You can also change the `version` parameter to load a different version of the data.
-from pathlib import Path
 
 import pandas as pd
 from mobgap.data.validation_results import ValidationResultLoader
@@ -87,13 +86,9 @@ def format_loaded_results(
     return formatted
 
 
-local_data_path = (
-    Path(get_env_var("MOBGAP_VALIDATION_DATA_PATH")) / "results"
-    if int(get_env_var("MOBGAP_VALIDATION_USE_LOCAL_DATA", 0))
-    else None
-)
+local_data_path = get_env_var("MOBGAP_VALIDATION_USE_LOCAL_DATA", None)
 loader = ValidationResultLoader(
-    "full_pipeline", result_path=local_data_path, version="main"
+    "full_pipeline", local_result_path=local_data_path
 )
 
 # Loading free-living data

--- a/revalidation/full_pipeline/_02_additional_experiments.py
+++ b/revalidation/full_pipeline/_02_additional_experiments.py
@@ -39,7 +39,6 @@ algorithms = {
 #
 # The file download will print a couple log information, which can usually be ignored.
 # You can also change the `version` parameter to load a different version of the data.
-from pathlib import Path
 
 import pandas as pd
 from mobgap.data.validation_results import ValidationResultLoader
@@ -81,15 +80,10 @@ def format_loaded_results(
     return formatted
 
 
-local_data_path = (
-    Path(get_env_var("MOBGAP_VALIDATION_DATA_PATH")) / "results"
-    if int(get_env_var("MOBGAP_VALIDATION_USE_LOCAL_DATA", 0))
-    else None
-)
+local_data_path = get_env_var("MOBGAP_VALIDATION_USE_LOCAL_DATA", None)
 loader = ValidationResultLoader(
     "full_pipeline",
-    result_path=local_data_path,
-    version="main",
+    local_result_path=local_data_path,
 )
 
 # Loading free-living data

--- a/revalidation/gait_sequences/_01_gsd_analysis.py
+++ b/revalidation/gait_sequences/_01_gsd_analysis.py
@@ -63,9 +63,7 @@ local_data_path = (
     if int(get_env_var("MOBGAP_VALIDATION_USE_LOCAL_DATA", 0))
     else None
 )
-loader = ValidationResultLoader(
-    "gsd", result_path=local_data_path, version="main"
-)
+loader = ValidationResultLoader("gsd", local_result_path=local_data_path)
 
 
 free_living_index_cols = [

--- a/revalidation/initial_contacts/_01_icd_analysis.py
+++ b/revalidation/initial_contacts/_01_icd_analysis.py
@@ -52,20 +52,13 @@ algorithms.update(
 #
 # The file download will print a couple log information, which can usually be ignored.
 # You can also change the `version` parameter to load a different version of the data.
-from pathlib import Path
 
 import pandas as pd
 from mobgap.data.validation_results import ValidationResultLoader
 from mobgap.utils.misc import get_env_var
 
-local_data_path = (
-    Path(get_env_var("MOBGAP_VALIDATION_DATA_PATH")) / "results"
-    if int(get_env_var("MOBGAP_VALIDATION_USE_LOCAL_DATA", 0))
-    else None
-)
-loader = ValidationResultLoader(
-    "icd", result_path=local_data_path, version="main"
-)
+local_data_path = get_env_var("MOBGAP_VALIDATION_USE_LOCAL_DATA", None)
+loader = ValidationResultLoader("icd", local_result_path=local_data_path)
 
 free_living_index_cols = [
     "cohort",

--- a/revalidation/laterality/_01_lrc_analysis.py
+++ b/revalidation/laterality/_01_lrc_analysis.py
@@ -49,7 +49,6 @@ algorithms = {
 #
 # The file download will print a couple log information, which can usually be ignored.
 # You can also change the `version` parameter to load a different version of the data.
-from pathlib import Path
 
 import pandas as pd
 from mobgap.data.validation_results import ValidationResultLoader
@@ -74,14 +73,8 @@ def format_loaded_results(
     return formatted
 
 
-local_data_path = (
-    Path(get_env_var("MOBGAP_VALIDATION_DATA_PATH")) / "results"
-    if int(get_env_var("MOBGAP_VALIDATION_USE_LOCAL_DATA", 0))
-    else None
-)
-loader = ValidationResultLoader(
-    "lrc", result_path=local_data_path, version="main"
-)
+local_data_path = get_env_var("MOBGAP_VALIDATION_USE_LOCAL_DATA", None)
+loader = ValidationResultLoader("lrc", local_result_path=local_data_path)
 
 
 free_living_index_cols = [

--- a/revalidation/stride_length/_01_sl_analysis.py
+++ b/revalidation/stride_length/_01_sl_analysis.py
@@ -42,7 +42,6 @@ algorithms = {
 #
 # The file download will print a couple log information, which can usually be ignored.
 # You can also change the `version` parameter to load a different version of the data.
-from pathlib import Path
 
 import pandas as pd
 from mobgap.data.validation_results import ValidationResultLoader
@@ -72,14 +71,8 @@ def format_loaded_results(
     return formatted
 
 
-local_data_path = (
-    Path(get_env_var("MOBGAP_VALIDATION_DATA_PATH")) / "results"
-    if int(get_env_var("MOBGAP_VALIDATION_USE_LOCAL_DATA", 0))
-    else None
-)
-loader = ValidationResultLoader(
-    "sl", result_path=local_data_path, version="main"
-)
+local_data_path = get_env_var("MOBGAP_VALIDATION_USE_LOCAL_DATA", None)
+loader = ValidationResultLoader("sl", local_result_path=local_data_path)
 
 
 free_living_index_cols = [


### PR DESCRIPTION
The validation downloader no tries to find the correct version of the result withou an explicit version provided.
This way the downloader should automatically get the correct results in most common cases.
Fore example, when you are working on a branch, it tries to load results from a branch witht he same name in the results repo (or falls back to main if not found).

Resolution order works as follows:

 1. If `local_result_path` is specified, we use this path and ignore the `version` parameter.
    2. If `local_result_path` is not specified, and `version` is specified, we use the `version` parameter.
       Results are then loaded as one request per file to the github api using the specified version as part of the URL.
    3. If `local_result_path` is not specified and `version` is not specified, we use the following logic to determine
       the version:
       - If the library has been installed as a dependency (vs. cloned from git for development), we use the version of
         the library as tag.
       - If the library has been cloned from git for development, we use the current we go in order of
         priority tag > branch.
         In case of a detached HEAD, we throw an error forcing you to specifying an explicit version that you want to
         load.
    4. When a version is automatically determined, we do a test request to the github api to see if the version is
       available.
       If not, we use the `fallback_version` parameter to load the results from.
       If this also fails, you will se the error message