### PR TITLE
Update recommended citation to published paper

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -98,6 +98,76 @@ identifiers:
       release, please follow the DOI link for one of the
       specific releases and grab DOI from the archived
       record.
+preferred-citation:
+  type: article
+  title: >-
+    Mobgap: A State-of-the-Art Python Framework for
+    Reproducible Estimation and Algorithm Validation of
+    Digital Mobility Outcomes from a Single Wearable Device
+  authors:
+    - given-names: Cameron
+      family-names: Kirk
+      orcid: 'https://orcid.org/0000-0003-2508-5816'
+    - given-names: Arne
+      family-names: Kuederle
+    - given-names: Paolo
+      family-names: Tasca
+      orcid: 'https://orcid.org/0009-0008-7157-3451'
+    - given-names: Metin
+      family-names: Bicer
+      orcid: 'https://orcid.org/0000-0002-9491-2080'
+    - given-names: Dimitrios
+      family-names: Megaritis
+      orcid: 'https://orcid.org/0000-0001-6786-4346'
+    - given-names: Eran
+      family-names: Gazit
+    - given-names: Tecla
+      family-names: Bonci
+      orcid: 'https://orcid.org/0000-0002-8255-4730'
+    - given-names: Anisora
+      family-names: Ionescu
+      orcid: 'https://orcid.org/0000-0002-2341-4383'
+    - given-names: Chloe
+      family-names: Hinchliffe
+    - given-names: Alexandru
+      family-names: Stihi
+      orcid: 'https://orcid.org/0000-0002-6073-671X'
+    - given-names: Anika
+      family-names: Muecke
+    - given-names: Zamal
+      family-names: Babar
+    - given-names: Ioannis
+      family-names: Vogiatzis
+      orcid: 'https://orcid.org/0000-0003-4830-7207'
+    - given-names: Bjoern
+      family-names: Eskofier
+      orcid: 'https://orcid.org/0000-0002-0417-0336'
+    - given-names: Claudia
+      family-names: Mazzà
+      orcid: 'https://orcid.org/0000-0002-5215-1746'
+    - given-names: Andrea
+      family-names: Cereatti
+      orcid: 'https://orcid.org/0000-0002-7276-5382'
+    - given-names: Arne
+      family-names: Mueller
+      orcid: 'https://orcid.org/0000-0001-6551-2283'
+    - given-names: Daniel
+      family-names: Rooks
+      orcid: 'https://orcid.org/0000-0002-1121-3517'
+    - given-names: Brian
+      family-names: Caulfield
+      orcid: 'https://orcid.org/0000-0003-0290-9587'
+    - given-names: Lynn
+      family-names: Rochester
+    - given-names: Silvia
+      family-names: Del Din
+      orcid: 'https://orcid.org/0000-0003-1154-4751'
+  doi: 10.3390/s26134294
+  journal: Sensors
+  volume: 26
+  issue: 13
+  month: 7
+  year: 2026
 repository-code: 'https://github.com/mobilise-d/mobgap/'
 url: 'https://mobgap.readthedocs.io/en/latest/README.html'
 repository: >-

--- a/README.md
+++ b/README.md
@@ -66,21 +66,28 @@ If you are using mobgap in your research or work, we would like to ask you to me
 For papers, we recommend citing the library using the following reference:
 
 ```
-Küderle, A., Tasca, P., Bicer, M., Kirk, C., Megaritis, D., Hinchliffe, C., Stihi, A., Muecke, A., Babar, Z., Kluge, F., Mueller, 
-A., Mazzà, C., Del Din, S., Cereatti, A., Rochester, L., Rooks, D., & Caulfield, B. 
-MobGap [Computer software]. https://doi.org/10.5281/zenodo.14035833 URL: https://github.com/mobilise-d/mobgap/ 
+Kirk, C., Kuederle, A., Tasca, P., et al. Mobgap: A State-of-the-Art Python Framework for Reproducible Estimation and
+Algorithm Validation of Digital Mobility Outcomes from a Single Wearable Device. Sensors 2026, 26(13), 4294.
+https://doi.org/10.3390/s26134294
 ```
 
 ```
-@software{Kuderle_MobGap,
-   author = {Küderle, Arne and Tasca, Paolo and Bicer, Metin and Kirk, Cameron and Megaritis, Dimitrios and Hinchliffe, Chloe and
-    Stihi, Alexandru and Muecke, Annika and Babar, Zamal and Kluge, Felix and Mueller, Arne and Mazzà, Claudia 
-    and Del Din, Silvia and Cereatti, Andrea and Rochester, Lynn and Rooks, Daniel and Caulfield, Brian},
-   license = {Apache-2.0},
-   title = {{MobGap}},
-   url = {https://github.com/mobilise-d/mobgap/}
-   doi = {10.5281/zenodo.14035833},
- }
+@article{kirk2026mobgap,
+  author = {Kirk, Cameron and Kuederle, Arne and Tasca, Paolo and Bicer, Metin and Megaritis, Dimitrios and Gazit, Eran
+    and Bonci, Tecla and Ionescu, Anisora and Hinchliffe, Chloe and Stihi, Alexandru and Muecke, Anika and Babar, Zamal
+    and Vogiatzis, Ioannis and Eskofier, Bjoern and Mazzà, Claudia and Cereatti, Andrea and Mueller, Arne and Rooks, Daniel
+    and Caulfield, Brian and Rochester, Lynn and Del Din, Silvia},
+  title = {Mobgap: A State-of-the-Art Python Framework for Reproducible Estimation and Algorithm Validation of Digital
+    Mobility Outcomes from a Single Wearable Device},
+  journal = {Sensors},
+  year = {2026},
+  month = {July},
+  volume = {26},
+  number = {13},
+  pages = {4294},
+  doi = {10.3390/s26134294},
+  url = {https://doi.org/10.3390/s26134294}
+}
 ```
 
 For concrete examples on how to cite the library in your work, see the [Usage Recommendation](#usage-recommendation) 
@@ -126,9 +133,9 @@ The package is designed to be used in two modes:
    Validation, insights and recommendations from the Mobilise-D consortium. J NeuroEngineering Rehabil 20, 78 (2023). 
    https://doi.org/10.1186/s12984-023-01198-5
    
-   [3] Küderle, A., Tasca, P., Bicer, M., Kirk, C., Megaritis, D., Hinchliffe, C., Stihi, A., Muecke, A., Babar, Z., Kluge, F., Mueller, 
-   A., Mazzà, C., Del Din, S., Cereatti, A., Rochester, L., Rooks, D., & Caulfield, B. 
-   MobGap [Computer software]. https://doi.org/10.5281/zenodo.14035833 URL: https://github.com/mobilise-d/mobgap/ 
+   [3] Kirk, C., Kuederle, A., Tasca, P., et al. Mobgap: A State-of-the-Art Python Framework for Reproducible Estimation
+   and Algorithm Validation of Digital Mobility Outcomes from a Single Wearable Device. Sensors 2026, 26(13), 4294.
+   https://doi.org/10.3390/s26134294
    ```
 
 2. Usage of individual algorithms:
@@ -147,14 +154,14 @@ The package is designed to be used in two modes:
    > mobgap Python library [[3]] version {insert version you used}.
 
    ```
-   [3] Küderle, A., Tasca, P., Bicer, M., Kirk, C., Megaritis, D., Hinchliffe, C., Stihi, A., Muecke, A., Babar, Z., Kluge, F., Mueller, 
-   A., Mazzà, C., Del Din, S., Cereatti, A., Rochester, L., Rooks, D., & Caulfield, B. 
-   MobGap [Computer software]. https://doi.org/10.5281/zenodo.14035833 URL: https://github.com/mobilise-d/mobgap/ 
+   [3] Kirk, C., Kuederle, A., Tasca, P., et al. Mobgap: A State-of-the-Art Python Framework for Reproducible Estimation
+   and Algorithm Validation of Digital Mobility Outcomes from a Single Wearable Device. Sensors 2026, 26(13), 4294.
+   https://doi.org/10.3390/s26134294
    ```
 
 [1]: https://doi.org/10.1038/s41598-024-51766-5
 [2]: https://doi.org/10.1186/s12984-023-01198-5
-[3]: https://github.com/mobilise-d/mobgap/
+[3]: https://doi.org/10.3390/s26134294
 
 ## Used by
 


### PR DESCRIPTION
## Summary

- replace the README's recommended software citation with the newly published mobgap paper
- update the BibTeX and usage-recommendation references to DOI `10.3390/s26134294`
- add the paper as the preferred citation in `CITATION.cff` while retaining the Zenodo DOI as the software identifier

## Impact

GitHub and README visitors will now be directed to cite the peer-reviewed publication describing mobgap. Version-specific software identification remains available through the existing Zenodo DOI.

## Validation

- `uvx --from cffconvert cffconvert --validate`
- `git diff --check`
- verified article metadata against the publisher and DOI metadata
