### PR TITLE
Adopt tpcp 2.3 features

### DIFF
--- a/.agents/refactor-policy.md
+++ b/.agents/refactor-policy.md
@@ -1,0 +1,5 @@
+# Backwards-compatibility policy
+
+- Backwards compatibility is mandatory for all public interfaces, user-facing behavior, and persisted data formats.
+- Internal refactors are allowed when safe; all in-repository consumers must be updated together and existing public behavior preserved.
+- Any public breaking change requires the project maintainer's explicit prior approval, a migration plan, and prominent release communication.

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,0 +1,6 @@
+# Project-specific review guidelines
+review_guidelines = """
+Flag any change that breaks a public interface, user-facing behavior, or persisted data format without explicit
+maintainer approval, a documented migration plan, and prominent release communication. Permit safe internal refactors
+only when all in-repository consumers are updated and public behavior remains stable.
+"""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+## Repository-local skills and refactoring
+
+- When the same skill name is available from multiple locations, always use the repository-local skill under `$REPO_ROOT/.agents/skills/`. Repository-local skills take precedence over user-global skills. Do not load or apply the corresponding skill from `$HOME/.agents/skills/` when a repository-local version exists.
+- Consider the repository's current publication state and backwards-compatibility requirements recorded in `.agents/refactor-policy.md` in all interactions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** `MisorientedDataset` now follows tpcp's dataset-wrapper convention: pass the source dataset as
   `wrapped_dataset` instead of `base_dataset`, and access it through the `wrapped_dataset` attribute.
 - Warnings and exceptions raised inside mobgap's iterative processing now identify the active pipeline, gait sequence,
-  walking bout, refined region, orientation, transformer, rule, aggregation, or transformation callback as applicable.
+  walking bout, refined region, orientation, transformer, rule, aggregation, transformation callback, revalidation
+  task, or input file as applicable.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The minimum supported `tpcp` version is now 2.3.0. Environments pinned to an older version must upgrade `tpcp`
+  before updating mobgap. This does not change mobgap's public APIs, but warnings and exceptions produced during tpcp
+  validation and optimization can now include structured fold, parameter, and datapoint context.
+
 ## [1.2.0] - 2026-04-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The minimum supported `tpcp` version is now 2.3.0. Environments pinned to an older version must upgrade `tpcp`
   before updating mobgap. This does not change mobgap's public APIs, but warnings and exceptions produced during tpcp
   validation and optimization can now include structured fold, parameter, and datapoint context.
+- **Breaking:** `MisorientedDataset` now follows tpcp's dataset-wrapper convention: pass the source dataset as
+  `wrapped_dataset` instead of `base_dataset`, and access it through the `wrapped_dataset` attribute.
+
+### Fixed
+
+- `MisorientedDataset` now preserves the wrapped dataset's grouping and appends its orientation column instead of
+  resetting iteration to every source-index row. Callers that intentionally need the previous row-level grouping can
+  pass all source-index columns plus the orientation column explicitly via `groupby_cols`.
 
 ## [1.2.0] - 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   validation and optimization can now include structured fold, parameter, and datapoint context.
 - **Breaking:** `MisorientedDataset` now follows tpcp's dataset-wrapper convention: pass the source dataset as
   `wrapped_dataset` instead of `base_dataset`, and access it through the `wrapped_dataset` attribute.
+- Warnings and exceptions raised inside mobgap's iterative processing now identify the active pipeline, gait sequence,
+  walking bout, refined region, orientation, transformer, rule, aggregation, or transformation callback as applicable.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires-python = ">=3.9,<3.15"
 readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
-    "tpcp>=2.2.1",
+    "tpcp>=2.3.0",
     "pandas>=2.2.0",
     "scipy>=1.11.2",
     "numpy>=1.25.2",

--- a/revalidation/_utils.py
+++ b/revalidation/_utils.py
@@ -1,0 +1,25 @@
+"""Shared helpers for revalidation scripts."""
+
+from collections.abc import Callable, Iterator, Mapping
+from typing import Any
+
+from tpcp.misc import iter_with_warning_error_context
+from tpcp.parallel import delayed
+
+
+def create_evaluation_tasks(
+    run_evaluation: Callable[[str, Any, Any], tuple[str, Any]],
+    pipelines: Mapping[str, Any],
+    dataset: Any,
+    *,
+    condition: str,
+) -> Iterator[Any]:
+    """Create context-aware delayed evaluation tasks."""
+    for make_context, (name, pipeline) in iter_with_warning_error_context(
+        pipelines.items()
+    ):
+        with make_context(
+            "revalidation", {"pipeline": name, "condition": condition}
+        ):
+            task = delayed(run_evaluation)(name, pipeline, dataset)
+        yield task

--- a/revalidation/cadence/_02_cadence_result_generation_no_exc.py
+++ b/revalidation/cadence/_02_cadence_result_generation_no_exc.py
@@ -244,7 +244,8 @@ pipelines["ShinImproved"] = CadEmulationPipeline(
 # recordings.
 # Depending on how you want to interpret the results, you might not want to use the aggregated results, but rather
 # perform custom aggregations over the provided "single_results".
-from joblib import Memory, Parallel, delayed
+from joblib import Memory
+from tpcp.parallel import Parallel, delayed
 from mobgap import PROJECT_ROOT
 from mobgap.data import TVSFreeLivingDataset, TVSLabDataset
 
@@ -266,7 +267,8 @@ datasets_laboratory = TVSLabDataset(
 # %%
 # Running the evaluation
 # ----------------------
-# We multiprocess the evaluation on the level of algorithms using joblib.
+# We multiprocess the evaluation on the level of algorithms using tpcp's
+# context-aware joblib helpers.
 # Each algorithm pipeline is run using its own instance of the :class:`~mobgap.evaluation.Evaluation` class.
 #
 # The evaluation object iterates over the entire dataset, runs the algorithm on each recording and calculates the

--- a/revalidation/cadence/_02_cadence_result_generation_no_exc.py
+++ b/revalidation/cadence/_02_cadence_result_generation_no_exc.py
@@ -245,9 +245,11 @@ pipelines["ShinImproved"] = CadEmulationPipeline(
 # Depending on how you want to interpret the results, you might not want to use the aggregated results, but rather
 # perform custom aggregations over the provided "single_results".
 from joblib import Memory
-from tpcp.parallel import Parallel, delayed
 from mobgap import PROJECT_ROOT
 from mobgap.data import TVSFreeLivingDataset, TVSLabDataset
+from tpcp.parallel import Parallel
+
+from revalidation._utils import create_evaluation_tasks
 
 cache_dir = Path(get_env_var("MOBGAP_CACHE_DIR_PATH", PROJECT_ROOT / ".cache"))
 
@@ -346,8 +348,12 @@ def eval_debug_plot(
 with Parallel(n_jobs=n_jobs) as parallel:
     results_free_living: dict[str, Evaluation[CadEmulationPipeline]] = dict(
         parallel(
-            delayed(run_evaluation)(name, pipeline, datasets_free_living)
-            for name, pipeline in pipelines.items()
+            create_evaluation_tasks(
+                run_evaluation,
+                pipelines,
+                datasets_free_living,
+                condition="free_living",
+            )
         )
     )
 
@@ -382,8 +388,12 @@ for k, v in results_free_living.items():
 with Parallel(n_jobs=n_jobs) as parallel:
     results_laboratory: dict[str, Evaluation[CadEmulationPipeline]] = dict(
         parallel(
-            delayed(run_evaluation)(name, pipeline, datasets_laboratory)
-            for name, pipeline in pipelines.items()
+            create_evaluation_tasks(
+                run_evaluation,
+                pipelines,
+                datasets_laboratory,
+                condition="laboratory",
+            )
         )
     )
 

--- a/revalidation/full_pipeline/_98_pipeline_with_misorientation_no_exc.py
+++ b/revalidation/full_pipeline/_98_pipeline_with_misorientation_no_exc.py
@@ -111,12 +111,12 @@ pipelines = {
 cache_dir = Path(get_env_var("MOBGAP_CACHE_DIR_PATH", PROJECT_ROOT / ".cache"))
 
 datasets_free_living = MisorientedDataset(
-    TVSFreeLivingDataset(
+    wrapped_dataset=TVSFreeLivingDataset(
         get_env_var("MOBGAP_TVS_DATASET_PATH"),
         reference_system="INDIP",
         memory=Memory(cache_dir),
         missing_reference_error_type="skip",
-    )
+    ),
 )
 
 # %%

--- a/revalidation/full_pipeline/_99_pipeline_result_generation_no_exc.py
+++ b/revalidation/full_pipeline/_99_pipeline_result_generation_no_exc.py
@@ -254,7 +254,8 @@ pipelines = {
 # Depending on how you want to interpret the results, you might not want to use the aggregated results, but rather
 # perform custom aggregations over the provided "single_results".
 
-from joblib import Memory, Parallel, delayed
+from joblib import Memory
+from tpcp.parallel import Parallel, delayed
 from mobgap import PROJECT_ROOT
 
 cache_dir = Path(get_env_var("MOBGAP_CACHE_DIR_PATH", PROJECT_ROOT / ".cache"))
@@ -277,7 +278,8 @@ datasets_laboratory = TVSLabDataset(
 # %%
 # Running the evaluation
 # ----------------------
-# We multiprocess the evaluation on the level of algorithms using joblib.
+# We multiprocess the evaluation on the level of algorithms using tpcp's
+# context-aware joblib helpers.
 # Each algorithm pipeline is run using its own instance of the :class:`~mobgap.evaluation.Evaluation` class.
 #
 # The evaluation object iterates over the entire dataset, runs the algorithm on each recording and calculates the

--- a/revalidation/full_pipeline/_99_pipeline_result_generation_no_exc.py
+++ b/revalidation/full_pipeline/_99_pipeline_result_generation_no_exc.py
@@ -255,8 +255,10 @@ pipelines = {
 # perform custom aggregations over the provided "single_results".
 
 from joblib import Memory
-from tpcp.parallel import Parallel, delayed
 from mobgap import PROJECT_ROOT
+from tpcp.parallel import Parallel
+
+from revalidation._utils import create_evaluation_tasks
 
 cache_dir = Path(get_env_var("MOBGAP_CACHE_DIR_PATH", PROJECT_ROOT / ".cache"))
 
@@ -347,8 +349,12 @@ with Parallel(n_jobs=n_jobs) as parallel:
     results_free_living: dict[str, Evaluation[MobilisedPipelineUniversal]] = (
         dict(
             parallel(
-                delayed(run_evaluation)(name, pipeline, datasets_free_living)
-                for name, pipeline in pipelines.items()
+                create_evaluation_tasks(
+                    run_evaluation,
+                    pipelines,
+                    datasets_free_living,
+                    condition="free_living",
+                )
             )
         )
     )
@@ -385,8 +391,12 @@ with Parallel(n_jobs=n_jobs) as parallel:
     results_laboratory: dict[str, Evaluation[MobilisedPipelineUniversal]] = (
         dict(
             parallel(
-                delayed(run_evaluation)(name, pipeline, datasets_laboratory)
-                for name, pipeline in pipelines.items()
+                create_evaluation_tasks(
+                    run_evaluation,
+                    pipelines,
+                    datasets_laboratory,
+                    condition="laboratory",
+                )
             )
         )
     )

--- a/revalidation/gait_sequences/_98_gsd_result_generation_no_exc.py
+++ b/revalidation/gait_sequences/_98_gsd_result_generation_no_exc.py
@@ -141,9 +141,11 @@ datasets_laboratory = TVSLabDataset(
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
-from tpcp.parallel import Parallel, delayed
 from mobgap.gait_sequences.evaluation import gsd_score
 from mobgap.utils.evaluation import Evaluation
+from tpcp.parallel import Parallel
+
+from revalidation._utils import create_evaluation_tasks
 
 n_jobs = int(get_env_var("MOBGAP_N_JOBS", 3))
 results_base_path = (
@@ -201,8 +203,12 @@ def eval_debug_plot(
 with Parallel(n_jobs=n_jobs) as parallel:
     results_free_living: dict[str, Evaluation[GsdEmulationPipeline]] = dict(
         parallel(
-            delayed(run_evaluation)(name, pipeline, datasets_free_living)
-            for name, pipeline in pipelines.items()
+            create_evaluation_tasks(
+                run_evaluation,
+                pipelines,
+                datasets_free_living,
+                condition="free_living",
+            )
         )
     )
 
@@ -232,8 +238,12 @@ for k, v in results_free_living.items():
 with Parallel(n_jobs=n_jobs) as parallel:
     results_laboratory: dict[str, Evaluation[GsdEmulationPipeline]] = dict(
         parallel(
-            delayed(run_evaluation)(name, pipeline, datasets_laboratory)
-            for name, pipeline in pipelines.items()
+            create_evaluation_tasks(
+                run_evaluation,
+                pipelines,
+                datasets_laboratory,
+                condition="laboratory",
+            )
         )
     )
 

--- a/revalidation/gait_sequences/_98_gsd_result_generation_no_exc.py
+++ b/revalidation/gait_sequences/_98_gsd_result_generation_no_exc.py
@@ -132,7 +132,8 @@ datasets_laboratory = TVSLabDataset(
 # %%
 # Running the evaluation
 # ----------------------
-# We multiprocess the evaluation on the level of algorithms using joblib.
+# We multiprocess the evaluation on the level of algorithms using tpcp's
+# context-aware joblib helpers.
 # Each algorithm pipeline is run using its own instance of the :class:`~mobgap.evaluation.Evaluation` class.
 #
 # The evaluation object iterates over the entire dataset, runs the algorithm on each recording and calculates the
@@ -140,7 +141,7 @@ datasets_laboratory = TVSLabDataset(
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
-from joblib import Parallel, delayed
+from tpcp.parallel import Parallel, delayed
 from mobgap.gait_sequences.evaluation import gsd_score
 from mobgap.utils.evaluation import Evaluation
 

--- a/revalidation/gait_sequences/_99_gsd_misorientation_result_generation_no_exc.py
+++ b/revalidation/gait_sequences/_99_gsd_misorientation_result_generation_no_exc.py
@@ -43,7 +43,6 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
 from joblib import Memory
-from tpcp.parallel import Parallel, delayed
 from mobgap import PROJECT_ROOT
 from mobgap.data import TVSFreeLivingDataset
 from mobgap.gait_sequences import GsdIluz, GsdIonescu
@@ -52,6 +51,9 @@ from mobgap.gait_sequences.pipeline import GsdEmulationPipeline
 from mobgap.re_orientation.evaluation import MisorientedDataset
 from mobgap.utils.evaluation import Evaluation, save_evaluation_results
 from mobgap.utils.misc import get_env_var
+from tpcp.parallel import Parallel
+
+from revalidation._utils import create_evaluation_tasks
 
 pipelines = {
     "GsdIluz": GsdEmulationPipeline(GsdIluz()),
@@ -135,8 +137,12 @@ def eval_debug_plot(
 with Parallel(n_jobs=n_jobs) as parallel:
     results_free_living: dict[str, Evaluation[GsdEmulationPipeline]] = dict(
         parallel(
-            delayed(run_evaluation)(name, pipeline, datasets_free_living)
-            for name, pipeline in pipelines.items()
+            create_evaluation_tasks(
+                run_evaluation,
+                pipelines,
+                datasets_free_living,
+                condition="free_living_misoriented",
+            )
         )
     )
 

--- a/revalidation/gait_sequences/_99_gsd_misorientation_result_generation_no_exc.py
+++ b/revalidation/gait_sequences/_99_gsd_misorientation_result_generation_no_exc.py
@@ -76,7 +76,7 @@ pipelines = {
 cache_dir = Path(get_env_var("MOBGAP_CACHE_DIR_PATH", PROJECT_ROOT / ".cache"))
 
 datasets_free_living = MisorientedDataset(
-    TVSFreeLivingDataset(
+    wrapped_dataset=TVSFreeLivingDataset(
         get_env_var("MOBGAP_TVS_DATASET_PATH"),
         reference_system="INDIP",
         memory=Memory(cache_dir),

--- a/revalidation/gait_sequences/_99_gsd_misorientation_result_generation_no_exc.py
+++ b/revalidation/gait_sequences/_99_gsd_misorientation_result_generation_no_exc.py
@@ -42,7 +42,8 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
-from joblib import Memory, Parallel, delayed
+from joblib import Memory
+from tpcp.parallel import Parallel, delayed
 from mobgap import PROJECT_ROOT
 from mobgap.data import TVSFreeLivingDataset
 from mobgap.gait_sequences import GsdIluz, GsdIonescu

--- a/revalidation/initial_contacts/_02_icd_result_generation_no_exc.py
+++ b/revalidation/initial_contacts/_02_icd_result_generation_no_exc.py
@@ -209,9 +209,11 @@ datasets_laboratory = TVSLabDataset(
 # score using the :func:`~mobgap.initial_contacts._evaluation_scorer.icd_score` function.
 import matplotlib.pyplot as plt
 import seaborn as sns
-from tpcp.parallel import Parallel, delayed
 from mobgap.initial_contacts.evaluation import icd_score
 from mobgap.utils.evaluation import Evaluation
+from tpcp.parallel import Parallel
+
+from revalidation._utils import create_evaluation_tasks
 
 n_jobs = int(get_env_var("MOBGAP_N_JOBS", 3))
 results_base_path = (
@@ -268,8 +270,12 @@ def eval_debug_plot(
 with Parallel(n_jobs=n_jobs) as parallel:
     results_free_living: dict[str, Evaluation[IcdEmulationPipeline]] = dict(
         parallel(
-            delayed(run_evaluation)(name, pipeline, datasets_free_living)
-            for name, pipeline in pipelines.items()
+            create_evaluation_tasks(
+                run_evaluation,
+                pipelines,
+                datasets_free_living,
+                condition="free_living",
+            )
         )
     )
 
@@ -299,8 +305,12 @@ for k, v in results_free_living.items():
 with Parallel(n_jobs=n_jobs) as parallel:
     results_laboratory: dict[str, Evaluation[IcdEmulationPipeline]] = dict(
         parallel(
-            delayed(run_evaluation)(name, pipeline, datasets_laboratory)
-            for name, pipeline in pipelines.items()
+            create_evaluation_tasks(
+                run_evaluation,
+                pipelines,
+                datasets_laboratory,
+                condition="laboratory",
+            )
         )
     )
 

--- a/revalidation/initial_contacts/_02_icd_result_generation_no_exc.py
+++ b/revalidation/initial_contacts/_02_icd_result_generation_no_exc.py
@@ -201,14 +201,15 @@ datasets_laboratory = TVSLabDataset(
 # %%
 # Running the evaluation
 # ----------------------
-# We multiprocess the evaluation on the level of algorithms using joblib.
+# We multiprocess the evaluation on the level of algorithms using tpcp's
+# context-aware joblib helpers.
 # Each algorithm pipeline is run using its own instance of the :class:`~mobgap.evaluation.Evaluation` class.
 #
 # The evaluation object iterates over the entire dataset, runs the algorithm on each recording and calculates the
 # score using the :func:`~mobgap.initial_contacts._evaluation_scorer.icd_score` function.
 import matplotlib.pyplot as plt
 import seaborn as sns
-from joblib import Parallel, delayed
+from tpcp.parallel import Parallel, delayed
 from mobgap.initial_contacts.evaluation import icd_score
 from mobgap.utils.evaluation import Evaluation
 

--- a/revalidation/laterality/_02_lrc_result_generation_no_exc.py
+++ b/revalidation/laterality/_02_lrc_result_generation_no_exc.py
@@ -92,7 +92,8 @@ datasets_laboratory = TVSLabDataset(
 # %%
 # Running the evaluation
 # ----------------------
-# We multiprocess the evaluation on the level of algorithms using joblib.
+# We multiprocess the evaluation on the level of algorithms using tpcp's
+# context-aware joblib helpers.
 # Each algorithm pipeline is run using its own instance of the :class:`~mobgap.evaluation.Evaluation` class.
 #
 # The evaluation object iterates over the entire dataset, runs the algorithm on each recording and calculates the
@@ -100,7 +101,7 @@ datasets_laboratory = TVSLabDataset(
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
-from joblib import Parallel, delayed
+from tpcp.parallel import Parallel, delayed
 from mobgap.laterality.evaluation import lrc_score
 from mobgap.utils.evaluation import Evaluation
 

--- a/revalidation/laterality/_02_lrc_result_generation_no_exc.py
+++ b/revalidation/laterality/_02_lrc_result_generation_no_exc.py
@@ -101,9 +101,11 @@ datasets_laboratory = TVSLabDataset(
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
-from tpcp.parallel import Parallel, delayed
 from mobgap.laterality.evaluation import lrc_score
 from mobgap.utils.evaluation import Evaluation
+from tpcp.parallel import Parallel
+
+from revalidation._utils import create_evaluation_tasks
 
 n_jobs = int(get_env_var("MOBGAP_N_JOBS", 3))
 results_base_path = (
@@ -150,8 +152,12 @@ def eval_debug_plot(
 with Parallel(n_jobs=n_jobs) as parallel:
     results_free_living: dict[str, Evaluation[LrcEmulationPipeline]] = dict(
         parallel(
-            delayed(run_evaluation)(name, pipeline, datasets_free_living)
-            for name, pipeline in pipelines.items()
+            create_evaluation_tasks(
+                run_evaluation,
+                pipelines,
+                datasets_free_living,
+                condition="free_living",
+            )
         )
     )
 
@@ -181,8 +187,12 @@ for k, v in results_free_living.items():
 with Parallel(n_jobs=n_jobs) as parallel:
     results_laboratory: dict[str, Evaluation[LrcEmulationPipeline]] = dict(
         parallel(
-            delayed(run_evaluation)(name, pipeline, datasets_laboratory)
-            for name, pipeline in pipelines.items()
+            create_evaluation_tasks(
+                run_evaluation,
+                pipelines,
+                datasets_laboratory,
+                condition="laboratory",
+            )
         )
     )
 

--- a/revalidation/re_orientation/_02_reorientation_result_generation_no_exc.py
+++ b/revalidation/re_orientation/_02_reorientation_result_generation_no_exc.py
@@ -85,13 +85,14 @@ datasets_laboratory = TVSLabDataset(
 # %%
 # Running the evaluation
 # ----------------------
-# We multiprocess the evaluation on the level of algorithms using joblib. Each
-# algorithm pipeline is run using its own instance of the
+# We multiprocess the evaluation on the level of algorithms using tpcp's
+# context-aware joblib helpers. Each algorithm pipeline is run using its own
+# instance of the
 # :class:`~mobgap.utils.evaluation.Evaluation` class.
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
-from joblib import Parallel, delayed
+from tpcp.parallel import Parallel, delayed
 from mobgap.re_orientation.evaluation import reorientation_score
 from mobgap.utils.evaluation import Evaluation
 

--- a/revalidation/re_orientation/_02_reorientation_result_generation_no_exc.py
+++ b/revalidation/re_orientation/_02_reorientation_result_generation_no_exc.py
@@ -92,9 +92,11 @@ datasets_laboratory = TVSLabDataset(
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
-from tpcp.parallel import Parallel, delayed
 from mobgap.re_orientation.evaluation import reorientation_score
 from mobgap.utils.evaluation import Evaluation
+from tpcp.parallel import Parallel
+
+from revalidation._utils import create_evaluation_tasks
 
 n_jobs = int(get_env_var("MOBGAP_N_JOBS", 3))
 results_base_path = (
@@ -142,8 +144,12 @@ with Parallel(n_jobs=n_jobs) as parallel:
         str, Evaluation[ReorientationEmulationPipeline]
     ] = dict(
         parallel(
-            delayed(run_evaluation)(name, pipeline, datasets_free_living)
-            for name, pipeline in pipelines.items()
+            create_evaluation_tasks(
+                run_evaluation,
+                pipelines,
+                datasets_free_living,
+                condition="free_living",
+            )
         )
     )
 
@@ -174,8 +180,12 @@ with Parallel(n_jobs=n_jobs) as parallel:
         str, Evaluation[ReorientationEmulationPipeline]
     ] = dict(
         parallel(
-            delayed(run_evaluation)(name, pipeline, datasets_laboratory)
-            for name, pipeline in pipelines.items()
+            create_evaluation_tasks(
+                run_evaluation,
+                pipelines,
+                datasets_laboratory,
+                condition="laboratory",
+            )
         )
     )
 

--- a/revalidation/stride_length/_02_sl_result_generation_no_exc.py
+++ b/revalidation/stride_length/_02_sl_result_generation_no_exc.py
@@ -248,9 +248,11 @@ pipelines["SlZjilstra__MS_MS"] = SlEmulationPipeline(
 # Depending on how you want to interpret the results, you might not want to use the aggregated results, but rather
 # perform custom aggregations over the provided "single_results".
 from joblib import Memory
-from tpcp.parallel import Parallel, delayed
 from mobgap import PROJECT_ROOT
 from mobgap.data import TVSFreeLivingDataset, TVSLabDataset
+from tpcp.parallel import Parallel
+
+from revalidation._utils import create_evaluation_tasks
 
 cache_dir = Path(get_env_var("MOBGAP_CACHE_DIR_PATH", PROJECT_ROOT / ".cache"))
 
@@ -349,8 +351,12 @@ def eval_debug_plot(
 with Parallel(n_jobs=n_jobs) as parallel:
     results_free_living: dict[str, Evaluation[SlEmulationPipeline]] = dict(
         parallel(
-            delayed(run_evaluation)(name, pipeline, datasets_free_living)
-            for name, pipeline in pipelines.items()
+            create_evaluation_tasks(
+                run_evaluation,
+                pipelines,
+                datasets_free_living,
+                condition="free_living",
+            )
         )
     )
 
@@ -384,8 +390,12 @@ for k, v in results_free_living.items():
 with Parallel(n_jobs=n_jobs) as parallel:
     results_laboratory: dict[str, Evaluation[SlEmulationPipeline]] = dict(
         parallel(
-            delayed(run_evaluation)(name, pipeline, datasets_laboratory)
-            for name, pipeline in pipelines.items()
+            create_evaluation_tasks(
+                run_evaluation,
+                pipelines,
+                datasets_laboratory,
+                condition="laboratory",
+            )
         )
     )
 

--- a/revalidation/stride_length/_02_sl_result_generation_no_exc.py
+++ b/revalidation/stride_length/_02_sl_result_generation_no_exc.py
@@ -247,7 +247,8 @@ pipelines["SlZjilstra__MS_MS"] = SlEmulationPipeline(
 # recordings.
 # Depending on how you want to interpret the results, you might not want to use the aggregated results, but rather
 # perform custom aggregations over the provided "single_results".
-from joblib import Memory, Parallel, delayed
+from joblib import Memory
+from tpcp.parallel import Parallel, delayed
 from mobgap import PROJECT_ROOT
 from mobgap.data import TVSFreeLivingDataset, TVSLabDataset
 
@@ -269,7 +270,8 @@ datasets_laboratory = TVSLabDataset(
 # %%
 # Running the evaluation
 # ----------------------
-# We multiprocess the evaluation on the level of algorithms using joblib.
+# We multiprocess the evaluation on the level of algorithms using tpcp's
+# context-aware joblib helpers.
 # Each algorithm pipeline is run using its own instance of the :class:`~mobgap.evaluation.Evaluation` class.
 #
 # The evaluation object iterates over the entire dataset, runs the algorithm on each recording and calculates the

--- a/src/mobgap/aggregation/_mobilised_aggregator.py
+++ b/src/mobgap/aggregation/_mobilised_aggregator.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 from pandas import option_context
 from tpcp import cf
-from tpcp.misc import set_defaults
+from tpcp.misc import iter_with_warning_error_context, set_defaults
 from typing_extensions import Self, Unpack
 
 from mobgap.aggregation.base import BaseAggregator, base_aggregator_docfiller
@@ -395,19 +395,20 @@ class MobilisedAggregator(BaseAggregator):
         the input data.
         """
         available_filters_and_aggs = []
-        for filt, aggs in self._FILTERS_AND_AGGS:
-            if all([filt is not None, "duration_s" not in data_columns]):
-                warnings.warn(
-                    f"Filter '{filt}' for walking bout length cannot be applied, "
-                    "because the data does not contain a 'duration_s' column.",
-                    stacklevel=2,
-                )
-                continue
+        for make_context, (filt, aggs) in iter_with_warning_error_context(self._FILTERS_AND_AGGS):
+            with make_context("dmo_aggregation_filter", {"filter": filt}):
+                if all([filt is not None, "duration_s" not in data_columns]):
+                    warnings.warn(
+                        f"Filter '{filt}' for walking bout length cannot be applied, "
+                        "because the data does not contain a 'duration_s' column.",
+                        stacklevel=2,
+                    )
+                    continue
 
-            # check if the property to aggregate is contained in data columns
-            available_aggs = {key: value for key, value in aggs.items() if value[0] in data_columns}
-            if available_aggs:
-                available_filters_and_aggs.append((filt, available_aggs))
+                # check if the property to aggregate is contained in data columns
+                available_aggs = {key: value for key, value in aggs.items() if value[0] in data_columns}
+                if available_aggs:
+                    available_filters_and_aggs.append((filt, available_aggs))
         return available_filters_and_aggs
 
     @staticmethod
@@ -418,13 +419,14 @@ class MobilisedAggregator(BaseAggregator):
     ) -> pd.DataFrame:
         """Apply filters and aggregations to the data."""
         aggregated_results = []
-        for f, agg in available_filters_and_aggs:
-            internal_filtered = filtered_data if f is None else filtered_data.query(f)
-            if groupby:
-                data_to_agg = internal_filtered.groupby(groupby)
-            else:
-                data_to_agg = internal_filtered.groupby(pd.Series("all_wbs", index=internal_filtered.index))
-            aggregated_results.append(data_to_agg.agg(**agg))
+        for make_context, (filt, agg) in iter_with_warning_error_context(available_filters_and_aggs):
+            with make_context("dmo_aggregation_filter", {"filter": filt}):
+                internal_filtered = filtered_data if filt is None else filtered_data.query(filt)
+                if groupby:
+                    data_to_agg = internal_filtered.groupby(groupby)
+                else:
+                    data_to_agg = internal_filtered.groupby(pd.Series("all_wbs", index=internal_filtered.index))
+                aggregated_results.append(data_to_agg.agg(**agg))
         return pd.concat(aggregated_results, axis=1)
 
     def _fillna_count_columns(self, data: pd.DataFrame) -> pd.DataFrame:

--- a/src/mobgap/cadence/pipeline.py
+++ b/src/mobgap/cadence/pipeline.py
@@ -113,27 +113,34 @@ class CadEmulationPipeline(OptimizablePipeline[BaseGaitDatasetWithReference]):
 
         result_algo_list = {}
         for (wb, _), r in wb_iterator.iterate(to_body_frame(datapoint.data_ss), ref_paras.wb_list):
-            r.ic_list = ref_paras.ic_list.loc[wb.id]
+            with wb_iterator.warning_error_context("walking_bout", {"wb_id": wb.id, "start": wb.start, "end": wb.end}):
+                r.ic_list = ref_paras.ic_list.loc[wb.id]
 
-            # The WBs from all reference systems are usually already defined so that they start and end with an
-            # initial contact.
-            # So refinement should not be required.
-            # We have it here in the pipeline, in case we use other data input in the future.
-            refined_wb_list, refined_ic_list = refine_gs(r.ic_list)
+                # The WBs from all reference systems are usually already defined so that they start and end with an
+                # initial contact.
+                # So refinement should not be required.
+                # We have it here in the pipeline, in case we use other data input in the future.
+                refined_wb_list, refined_ic_list = refine_gs(r.ic_list)
 
-            with wb_iterator.subregion(refined_wb_list) as ((refined_wb, refined_gs_data), rr):
-                # Not quite happy, that we have to pass the current-gs offset here, but I don't see an easy way to
-                # still make this pipeline universally usable and support our revalidation dummy algos.
-                current_wb_absolute = Region(wb.id, wb.start + refined_wb.start, wb.end + refined_wb.start)
-                algo = self.algo.clone().calculate(
-                    refined_gs_data,
-                    initial_contacts=refined_ic_list,
-                    **kwargs,
-                    current_gs=refined_wb,
-                    current_gs_absolute=current_wb_absolute,
-                )
-                result_algo_list[wb.id] = algo
-                rr.cadence_per_sec = algo.cadence_per_sec_
+                with (
+                    wb_iterator.subregion(refined_wb_list) as ((refined_wb, refined_gs_data), rr),
+                    wb_iterator.warning_error_context(
+                        "refined_walking_bout",
+                        {"wb_id": refined_wb.id, "start": refined_wb.start, "end": refined_wb.end},
+                    ),
+                ):
+                    # Not quite happy, that we have to pass the current-gs offset here, but I don't see an easy way
+                    # to still make this pipeline universally usable and support our revalidation dummy algos.
+                    current_wb_absolute = Region(wb.id, wb.start + refined_wb.start, wb.end + refined_wb.start)
+                    algo = self.algo.clone().calculate(
+                        refined_gs_data,
+                        initial_contacts=refined_ic_list,
+                        **kwargs,
+                        current_gs=refined_wb,
+                        current_gs_absolute=current_wb_absolute,
+                    )
+                    result_algo_list[wb.id] = algo
+                    rr.cadence_per_sec = algo.cadence_per_sec_
 
         # The Cad algorithms provide outputs per second of each WB.
         # We further provide interpolated outputs per stride.

--- a/src/mobgap/data/_mobilised_cvs_dmo_dataset.py
+++ b/src/mobgap/data/_mobilised_cvs_dmo_dataset.py
@@ -1,12 +1,15 @@
 import warnings
+from collections.abc import Iterator
 from functools import lru_cache
 from pathlib import Path
-from typing import ClassVar, Literal, Optional, Union
+from typing import Any, ClassVar, Literal, Optional, Union
 
 import pandas as pd
-from joblib import Memory, Parallel, delayed
+from joblib import Memory
 from tpcp import Dataset
 from tpcp.caching import hybrid_cache
+from tpcp.misc import iter_with_warning_error_context
+from tpcp.parallel import Parallel, delayed
 from tqdm.auto import tqdm
 
 from mobgap.data._mobilsed_weartime_loader import load_weartime_from_daily_mcroberts_report
@@ -421,9 +424,15 @@ class MobilisedCvsDmoDataset(Dataset):
         # Note: We use multiprocessing here, as this can speed up the computation significantly.
         #       However, we are still primarily bound by the IO speed of the hard drive, so to many processes will
         #       not help.
+        def create_tasks() -> Iterator[Any]:
+            for make_context, file_path in iter_with_warning_error_context(filelist):
+                with make_context("wear_time_file", {"path": str(file_path)}):
+                    task = delayed(process_single_file)(file_path)
+                yield task
+
         results = list(
             tqdm(
-                Parallel(n_jobs=3, return_as="generator")(delayed(process_single_file)(f) for f in filelist),
+                Parallel(n_jobs=3, return_as="generator")(create_tasks()),
                 total=len(filelist),
                 desc="Loading daily weartime reports for participants",
             )

--- a/src/mobgap/data/_mobilised_matlab_loader.py
+++ b/src/mobgap/data/_mobilised_matlab_loader.py
@@ -1269,7 +1269,8 @@ class BaseGenericMobilisedDataset(BaseGaitDatasetWithReference):
 
         import json  # noqa: PLC0415
 
-        from joblib import Parallel, delayed  # noqa: PLC0415
+        from tpcp.misc import iter_with_warning_error_context  # noqa: PLC0415
+        from tpcp.parallel import Parallel, delayed  # noqa: PLC0415
 
         def process_path(p: str, rel_out_path: str) -> Path:
             _, available_data_per_test = _load_test_data_without_checks(p)
@@ -1286,10 +1287,14 @@ class BaseGenericMobilisedDataset(BaseGaitDatasetWithReference):
                 json.dump(available_data_per_test, f, indent=4)
             return out_path
 
+        def create_tasks() -> Iterator[Any]:
+            for make_context, path in iter_with_warning_error_context(self._paths_list):
+                with make_context("matlab_file", {"path": str(path)}):
+                    task = delayed(process_path)(path, rel_out_path)
+                yield task
+
         pbar = tqdm(
-            Parallel(n_jobs=n_jobs, return_as="generator")(
-                delayed(process_path)(p, rel_out_path) for p in self._paths_list
-            ),
+            Parallel(n_jobs=n_jobs, return_as="generator")(create_tasks()),
             total=len(self._paths_list),
             desc="Creating precomputed test list.",
         )

--- a/src/mobgap/data_transform/_utils.py
+++ b/src/mobgap/data_transform/_utils.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from tpcp.misc import iter_with_warning_error_context
 from typing_extensions import Unpack
 
 from mobgap.data_transform.base import BaseTransformer
@@ -27,15 +28,16 @@ def chain_transformers(
         The transformed data.
 
     """
-    for name, transformer in transformers:
-        try:
-            transformer_with_results = transformer.transform(data, **kwargs)
-            data = transformer_with_results.transformed_data_
-        except Exception as e:
-            raise RuntimeError(
-                f"Error while applying transformer '{name}' in the transformer chain. "
-                "Scroll up to see the full traceback of this error."
-            ) from e
-        # We ask the transformer that was just use to potentially update the kwargs for the next transformer
-        kwargs = transformer_with_results._get_updated_chain_kwargs(**kwargs)
+    for make_context, (name, transformer) in iter_with_warning_error_context(transformers):
+        with make_context("transformer", {"name": name}):
+            try:
+                transformer_with_results = transformer.transform(data, **kwargs)
+                data = transformer_with_results.transformed_data_
+            except Exception as e:
+                raise RuntimeError(
+                    f"Error while applying transformer '{name}' in the transformer chain. "
+                    "Scroll up to see the full traceback of this error."
+                ) from e
+            # We ask the transformer that was just use to potentially update the kwargs for the next transformer
+            kwargs = transformer_with_results._get_updated_chain_kwargs(**kwargs)
     return data

--- a/src/mobgap/initial_contacts/pipeline.py
+++ b/src/mobgap/initial_contacts/pipeline.py
@@ -116,9 +116,10 @@ class IcdEmulationPipeline(OptimizablePipeline[BaseGaitDatasetWithReference]):
         wb_iterator = GsIterator()
         result_algo_list = {}
         for (wb, data), r in wb_iterator.iterate(imu_data, ref_paras.wb_list):
-            algo = self.algo.clone().detect(data, **kwargs, current_gs=wb)
-            result_algo_list[wb.id] = algo
-            r.ic_list = algo.ic_list_
+            with wb_iterator.warning_error_context("walking_bout", {"wb_id": wb.id, "start": wb.start, "end": wb.end}):
+                algo = self.algo.clone().detect(data, **kwargs, current_gs=wb)
+                result_algo_list[wb.id] = algo
+                r.ic_list = algo.ic_list_
         self.per_wb_algo_ = result_algo_list
         self.ic_list_ = wb_iterator.results_.ic_list
         return self

--- a/src/mobgap/laterality/pipeline.py
+++ b/src/mobgap/laterality/pipeline.py
@@ -104,12 +104,13 @@ class LrcEmulationPipeline(OptimizablePipeline[BaseGaitDatasetWithReference]):
         # TODO: maybe do it properly and create a custom iter type
         result_algo_list = {}
         for (wb, data), r in wb_iterator.iterate(to_body_frame(datapoint.data_ss), ref_paras.wb_list):
-            ref_ic_list = ref_paras.ic_list.loc[wb.id]
-            algo = self.algo.clone().predict(
-                data, ref_ic_list.drop("lr_label", axis=1, errors="ignore"), sampling_rate_hz=sampling_rate_hz
-            )
-            result_algo_list[wb.id] = algo
-            r.ic_list = algo.ic_lr_list_
+            with wb_iterator.warning_error_context("walking_bout", {"wb_id": wb.id, "start": wb.start, "end": wb.end}):
+                ref_ic_list = ref_paras.ic_list.loc[wb.id]
+                algo = self.algo.clone().predict(
+                    data, ref_ic_list.drop("lr_label", axis=1, errors="ignore"), sampling_rate_hz=sampling_rate_hz
+                )
+                result_algo_list[wb.id] = algo
+                r.ic_list = algo.ic_lr_list_
 
         self.per_wb_algo_ = result_algo_list
         self.ic_lr_list_ = wb_iterator.results_.ic_list.pipe(_unify_ic_lr_list_df)

--- a/src/mobgap/pipeline/_mobilised_pipeline.py
+++ b/src/mobgap/pipeline/_mobilised_pipeline.py
@@ -5,7 +5,7 @@ from typing import Any, Final, Generic, Optional
 
 import pandas as pd
 from tpcp import cf
-from tpcp.misc import set_defaults
+from tpcp.misc import iter_with_warning_error_context, set_defaults
 from typing_extensions import Self
 
 from mobgap._utils_internal.misc import timed_action_method
@@ -348,54 +348,64 @@ class GenericMobilisedPipeline(BaseMobilisedPipeline[BaseGaitDatasetT], Generic[
         gs_iterator = GsIterator[FullPipelinePerGsResult]()
         # TODO: How to expose the individual algo instances of the algos that run in the loop?
 
-        for (_, gs_data), r in gs_iterator.iterate(imu_data, gait_sequences):
-            if self.per_gs_reorientation is not None:
-                reorient = self.per_gs_reorientation.clone().detect_correct(
-                    gs_data, sampling_rate_hz=action_kwargs["sampling_rate_hz"]
-                )
-                gs_data = reorient.corrected_data_  # noqa: PLW2901
-                r.reorientation_result = reorient.result_
-
-            icd = self.initial_contact_detection.clone().detect(gs_data, **action_kwargs)
-            lrc = self.laterality_classification.clone().predict(gs_data, icd.ic_list_, **action_kwargs)
-            r.ic_list = lrc.ic_lr_list_
-            if self.turn_detection:
-                turn = self.turn_detection.clone().detect(gs_data, **action_kwargs)
-                r.turn_list = turn.turn_list_
-
-            if len(r.ic_list) < 2:
-                # We need at least two initial contacts to calculate the per-second parameters, so we skip the rest of
-                # the loop if there are less than 2 initial contacts.
-                # This also fixes #227
-                continue
-            refined_gs, refined_ic_list = refine_gs(r.ic_list)
-
-            with gs_iterator.subregion(refined_gs, data=gs_data) as ((_, refined_gs_data), rr):
-                cad_r = None
-                if self.cadence_calculation:
-                    cad = self.cadence_calculation.clone().calculate(
-                        refined_gs_data,
-                        initial_contacts=refined_ic_list,
-                        **action_kwargs,
+        for (gs, gs_data), r in gs_iterator.iterate(imu_data, gait_sequences):
+            with gs_iterator.warning_error_context("gait_sequence", {"gs_id": gs.id, "start": gs.start, "end": gs.end}):
+                if self.per_gs_reorientation is not None:
+                    reorient = self.per_gs_reorientation.clone().detect_correct(
+                        gs_data, sampling_rate_hz=action_kwargs["sampling_rate_hz"]
                     )
-                    cad_r = cad.cadence_per_sec_
-                    rr.cadence_per_sec = cad_r
-                sl_r = None
-                if self.stride_length_calculation:
-                    sl = self.stride_length_calculation.clone().calculate(
-                        refined_gs_data, initial_contacts=refined_ic_list, **action_kwargs
-                    )
-                    sl_r = sl.stride_length_per_sec_
-                    rr.stride_length_per_sec = sl.stride_length_per_sec_
-                if self.walking_speed_calculation:
-                    ws = self.walking_speed_calculation.clone().calculate(
-                        refined_gs_data,
-                        initial_contacts=refined_ic_list,
-                        cadence_per_sec=cad_r,
-                        stride_length_per_sec=sl_r,
-                        **action_kwargs,
-                    )
-                    rr.walking_speed_per_sec = ws.walking_speed_per_sec_
+                    gs_data = reorient.corrected_data_  # noqa: PLW2901
+                    r.reorientation_result = reorient.result_
+
+                icd = self.initial_contact_detection.clone().detect(gs_data, **action_kwargs)
+                lrc = self.laterality_classification.clone().predict(gs_data, icd.ic_list_, **action_kwargs)
+                r.ic_list = lrc.ic_lr_list_
+                if self.turn_detection:
+                    turn = self.turn_detection.clone().detect(gs_data, **action_kwargs)
+                    r.turn_list = turn.turn_list_
+
+                if len(r.ic_list) < 2:
+                    # We need at least two initial contacts to calculate the per-second parameters, so we skip the rest
+                    # of the loop if there are less than 2 initial contacts. This also fixes #227.
+                    continue
+                refined_gs, refined_ic_list = refine_gs(r.ic_list)
+
+                with (
+                    gs_iterator.subregion(refined_gs, data=gs_data) as ((refined_region, refined_gs_data), rr),
+                    gs_iterator.warning_error_context(
+                        "refined_gait_sequence",
+                        {
+                            "gs_id": refined_region.id,
+                            "start": refined_region.start,
+                            "end": refined_region.end,
+                        },
+                    ),
+                ):
+                    cad_r = None
+                    if self.cadence_calculation:
+                        cad = self.cadence_calculation.clone().calculate(
+                            refined_gs_data,
+                            initial_contacts=refined_ic_list,
+                            **action_kwargs,
+                        )
+                        cad_r = cad.cadence_per_sec_
+                        rr.cadence_per_sec = cad_r
+                    sl_r = None
+                    if self.stride_length_calculation:
+                        sl = self.stride_length_calculation.clone().calculate(
+                            refined_gs_data, initial_contacts=refined_ic_list, **action_kwargs
+                        )
+                        sl_r = sl.stride_length_per_sec_
+                        rr.stride_length_per_sec = sl.stride_length_per_sec_
+                    if self.walking_speed_calculation:
+                        ws = self.walking_speed_calculation.clone().calculate(
+                            refined_gs_data,
+                            initial_contacts=refined_ic_list,
+                            cadence_per_sec=cad_r,
+                            stride_length_per_sec=sl_r,
+                            **action_kwargs,
+                        )
+                        rr.walking_speed_per_sec = ws.walking_speed_per_sec_
 
         return gs_iterator
 
@@ -753,16 +763,17 @@ class MobilisedPipelineUniversal(BaseMobilisedPipeline[BaseGaitDatasetT], Generi
                 union = set(p1[1].get_recommended_cohorts()) & set(p2[1].get_recommended_cohorts())
                 if union:
                     raise ValueError(
-                        f"The provided pipelines with the names {p1[0]} and {p2[0]} have an overlap in the recommended "
-                        f"cohorts: {union}"
+                        f"The provided pipelines with the names {p1[0]} and {p2[0]} have an overlap in the "
+                        f"recommended cohorts: {union}"
                     )
 
         cohort = datapoint.participant_metadata["cohort"]
-        for name, pipeline in self.pipelines:
-            if pipeline.get_recommended_cohorts() and cohort in pipeline.get_recommended_cohorts():
-                self.pipeline_ = pipeline.clone().run(datapoint)
-                self.pipeline_name_ = name
-                return self
+        for make_context, (name, pipeline) in iter_with_warning_error_context(self.pipelines):
+            with make_context("pipeline", {"name": name, "cohort": cohort}):
+                if pipeline.get_recommended_cohorts() and cohort in pipeline.get_recommended_cohorts():
+                    self.pipeline_ = pipeline.clone().run(datapoint)
+                    self.pipeline_name_ = name
+                    return self
         raise ValueError(
             f"Could not determine the correct pipeline for the cohort {cohort}. "
             "Check the ``get_recommended_cohorts`` attribute of the pipelines."

--- a/src/mobgap/re_orientation/evaluation.py
+++ b/src/mobgap/re_orientation/evaluation.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 from scipy.spatial.transform import Rotation
 from sklearn.metrics import accuracy_score, confusion_matrix
+from tpcp import DatasetWrapperMixin
 from tpcp.validate import Scorer, no_agg
 
 from mobgap._gaitmap.utils.rotations import flip_dataset
@@ -28,10 +29,14 @@ from mobgap.utils.dtypes import get_frame_definition
 OrientationSpec = Optional[Union[Mapping[str, Rotation], Sequence[str]]]
 
 
-class MisorientedDataset(BaseGaitDatasetWithReference):
+class MisorientedDataset(
+    DatasetWrapperMixin[BaseGaitDatasetWithReference],
+    BaseGaitDatasetWithReference,
+):
     """Wrap a dataset and simulate mounting orientations per recording.
 
     The wrapped dataset index is expanded by an additional ``orientation`` column.
+    Its existing grouping is preserved and extended with that column.
     Data access delegates to the matching row of the wrapped dataset, converts each
     signal to body frame to apply the selected rough mounting rotation, and returns
     it in the same frame as the wrapped dataset.
@@ -42,7 +47,7 @@ class MisorientedDataset(BaseGaitDatasetWithReference):
 
     Parameters
     ----------
-    base_dataset
+    wrapped_dataset
         Dataset to wrap.
     orientations
         Either a mapping from orientation labels to rotations, or a sequence of
@@ -56,20 +61,20 @@ class MisorientedDataset(BaseGaitDatasetWithReference):
         Selected subset of the expanded index. See :class:`tpcp.Dataset`.
     """
 
-    base_dataset: BaseGaitDatasetWithReference
+    wrapped_dataset: BaseGaitDatasetWithReference
     orientations: OrientationSpec
     orientation_col: str
 
     def __init__(
         self,
-        base_dataset: BaseGaitDatasetWithReference,
+        wrapped_dataset: BaseGaitDatasetWithReference,
         orientations: OrientationSpec = None,
         *,
         orientation_col: str = "orientation",
         groupby_cols: Optional[Union[list[str], str]] = None,
         subset_index: Optional[pd.DataFrame] = None,
     ) -> None:
-        self.base_dataset = base_dataset
+        self.wrapped_dataset = wrapped_dataset
         self.orientations = orientations
         self.orientation_col = orientation_col
         super().__init__(groupby_cols=groupby_cols, subset_index=subset_index)
@@ -86,7 +91,7 @@ class MisorientedDataset(BaseGaitDatasetWithReference):
     @property
     def orientation_label(self) -> str:
         """Return simulated orientation label for one dataset subset."""
-        self.assert_is_single(None, "orientation_label")
+        self.assert_is_single_group("orientation_label")
         return getattr(self.group_label, self.orientation_col)
 
     @property
@@ -94,22 +99,19 @@ class MisorientedDataset(BaseGaitDatasetWithReference):
         """Return simulated orientation rotation for one dataset subset."""
         return self.orientation_map[self.orientation_label]
 
-    def create_index(self) -> pd.DataFrame:
+    @property
+    def _wrapper_groupby_cols(self) -> tuple[str, ...]:
+        return (self.orientation_col,)
+
+    def _create_wrapped_index(self, source_index: pd.DataFrame) -> pd.DataFrame:
         """Expand the wrapped dataset index by configured orientation labels."""
-        base_index = self.base_dataset.index
-        if self.orientation_col in base_index.columns:
+        if self.orientation_col in source_index.columns:
             raise ValueError(f"Wrapped dataset already contains an `{self.orientation_col}` column.")
 
         orientation_labels = list(self.orientation_map)
-        expanded_index = base_index.loc[base_index.index.repeat(len(orientation_labels))].reset_index(drop=True)
-        expanded_index[self.orientation_col] = orientation_labels * len(base_index)
+        expanded_index = source_index.loc[source_index.index.repeat(len(orientation_labels))].reset_index(drop=True)
+        expanded_index[self.orientation_col] = orientation_labels * len(source_index)
         return expanded_index
-
-    @property
-    def _base_datapoint(self) -> BaseGaitDatasetWithReference:
-        self.assert_is_single(None, "_base_datapoint")
-        base_index = self.index.drop(columns=self.orientation_col)
-        return self.base_dataset.get_subset(index=base_index)
 
     def _rotate_imu_data(self, data: pd.DataFrame) -> pd.DataFrame:
         frame = get_frame_definition(data, ["sensor", "body"])
@@ -122,42 +124,44 @@ class MisorientedDataset(BaseGaitDatasetWithReference):
     @property
     def data(self) -> IMU_DATA_DTYPE:
         """Return all sensor data with simulated orientation applied."""
-        return {sensor: self._rotate_imu_data(sensor_data) for sensor, sensor_data in self._base_datapoint.data.items()}
+        return {
+            sensor: self._rotate_imu_data(sensor_data) for sensor, sensor_data in self.wrapped_datapoint.data.items()
+        }
 
     @property
     def data_ss(self) -> pd.DataFrame:
         """Return single-sensor data with simulated orientation applied."""
-        return self._rotate_imu_data(self._base_datapoint.data_ss)
+        return self._rotate_imu_data(self.wrapped_datapoint.data_ss)
 
     @property
     def sampling_rate_hz(self) -> float:
         """Return sampling rate from the wrapped datapoint."""
-        return self._base_datapoint.sampling_rate_hz
+        return self.wrapped_datapoint.sampling_rate_hz
 
     @property
     def participant_metadata(self) -> ParticipantMetadata:
         """Return participant metadata from the wrapped datapoint."""
-        return self._base_datapoint.participant_metadata
+        return self.wrapped_datapoint.participant_metadata
 
     @property
     def recording_metadata(self) -> RecordingMetadata:
         """Return recording metadata from the wrapped datapoint."""
-        return self._base_datapoint.recording_metadata
+        return self.wrapped_datapoint.recording_metadata
 
     @property
     def reference_parameters_(self) -> ReferenceData:
         """Return reference parameters from the wrapped datapoint."""
-        return self._base_datapoint.reference_parameters_
+        return self.wrapped_datapoint.reference_parameters_
 
     @property
     def reference_parameters_relative_to_wb_(self) -> ReferenceData:
         """Return WB-relative reference parameters from the wrapped datapoint."""
-        return self._base_datapoint.reference_parameters_relative_to_wb_
+        return self.wrapped_datapoint.reference_parameters_relative_to_wb_
 
     @property
     def reference_sampling_rate_hz_(self) -> float:
         """Return reference sampling rate from the wrapped datapoint."""
-        return self._base_datapoint.reference_sampling_rate_hz_
+        return self.wrapped_datapoint.reference_sampling_rate_hz_
 
 
 def _confusion_matrix_as_df(predictions: pd.DataFrame) -> pd.DataFrame:

--- a/src/mobgap/re_orientation/pipeline.py
+++ b/src/mobgap/re_orientation/pipeline.py
@@ -5,6 +5,7 @@ from collections.abc import Hashable
 import pandas as pd
 from scipy.spatial.transform import Rotation
 from tpcp import OptimizableParameter, Pipeline
+from tpcp.misc import iter_with_warning_error_context
 from typing_extensions import Self
 
 from mobgap._gaitmap.utils.rotations import flip_dataset
@@ -123,21 +124,27 @@ class ReorientationEmulationPipeline(Pipeline[BaseGaitDatasetWithReference]):
         predictions_per_wb = {}
         predictions = []
 
-        for wb, wb_data in iter_gs(data, wb_list):
-            wb_predictions = []
-            for label, rotation in REORIENTATION_ROTATIONS.items():
-                rotated_data = flip_dataset(wb_data, rotation)
-                algo = self.algo.clone().detect_correct(rotated_data, sampling_rate_hz=datapoint.sampling_rate_hz)
-                result_algo_list[(wb.id, label)] = algo
-                wb_predictions.append(
-                    {
-                        "wb_id": wb.id,
-                        "label": label,
-                        "prediction": _orientation_class_from_result(algo),
-                    }
-                )
-            predictions_per_wb[wb.id] = pd.DataFrame(wb_predictions)[["label", "prediction"]]
-            predictions.extend(wb_predictions)
+        for make_wb_context, (wb, wb_data) in iter_with_warning_error_context(iter_gs(data, wb_list)):
+            with make_wb_context("walking_bout", {"wb_id": wb.id, "start": wb.start, "end": wb.end}):
+                wb_predictions = []
+                for make_orientation_context, (label, rotation) in iter_with_warning_error_context(
+                    REORIENTATION_ROTATIONS.items()
+                ):
+                    with make_orientation_context("orientation", {"label": label}):
+                        rotated_data = flip_dataset(wb_data, rotation)
+                        algo = self.algo.clone().detect_correct(
+                            rotated_data, sampling_rate_hz=datapoint.sampling_rate_hz
+                        )
+                        result_algo_list[(wb.id, label)] = algo
+                        wb_predictions.append(
+                            {
+                                "wb_id": wb.id,
+                                "label": label,
+                                "prediction": _orientation_class_from_result(algo),
+                            }
+                        )
+                predictions_per_wb[wb.id] = pd.DataFrame(wb_predictions)[["label", "prediction"]]
+                predictions.extend(wb_predictions)
 
         self.per_wb_algo_ = result_algo_list
         self.predictions_per_wb_ = predictions_per_wb

--- a/src/mobgap/stride_length/pipeline.py
+++ b/src/mobgap/stride_length/pipeline.py
@@ -114,27 +114,34 @@ class SlEmulationPipeline(OptimizablePipeline[BaseGaitDatasetWithReference]):
 
         result_algo_list = {}
         for (wb, _), r in wb_iterator.iterate(to_body_frame(datapoint.data_ss), ref_paras.wb_list):
-            r.ic_list = ref_paras.ic_list.loc[wb.id]
+            with wb_iterator.warning_error_context("walking_bout", {"wb_id": wb.id, "start": wb.start, "end": wb.end}):
+                r.ic_list = ref_paras.ic_list.loc[wb.id]
 
-            # The WBs from all reference systems are usually already defined so that they start and end with an
-            # initial contact.
-            # So refinement should not be required.
-            # We have it here in the pipeline, in case we use other data input in the future.
-            refined_wb_list, refined_ic_list = refine_gs(r.ic_list)
+                # The WBs from all reference systems are usually already defined so that they start and end with an
+                # initial contact.
+                # So refinement should not be required.
+                # We have it here in the pipeline, in case we use other data input in the future.
+                refined_wb_list, refined_ic_list = refine_gs(r.ic_list)
 
-            with wb_iterator.subregion(refined_wb_list) as ((refined_wb, refined_gs_data), rr):
-                # Not quite happy, that we have to pass the current-gs offset here, but I don't see an easy way to
-                # still make this pipeline universally usable and support our revalidation dummy algos.
-                current_wb_absolute = Region(wb.id, wb.start + refined_wb.start, wb.end + refined_wb.start)
-                algo = self.algo.clone().calculate(
-                    refined_gs_data,
-                    refined_ic_list,
-                    **kwargs,
-                    current_gs=refined_wb,
-                    current_gs_absolute=current_wb_absolute,
-                )
-                result_algo_list[wb.id] = algo
-                rr.stride_length_per_sec = algo.stride_length_per_sec_
+                with (
+                    wb_iterator.subregion(refined_wb_list) as ((refined_wb, refined_gs_data), rr),
+                    wb_iterator.warning_error_context(
+                        "refined_walking_bout",
+                        {"wb_id": refined_wb.id, "start": refined_wb.start, "end": refined_wb.end},
+                    ),
+                ):
+                    # Not quite happy, that we have to pass the current-gs offset here, but I don't see an easy way
+                    # to still make this pipeline universally usable and support our revalidation dummy algos.
+                    current_wb_absolute = Region(wb.id, wb.start + refined_wb.start, wb.end + refined_wb.start)
+                    algo = self.algo.clone().calculate(
+                        refined_gs_data,
+                        refined_ic_list,
+                        **kwargs,
+                        current_gs=refined_wb,
+                        current_gs_absolute=current_wb_absolute,
+                    )
+                    result_algo_list[wb.id] = algo
+                    rr.stride_length_per_sec = algo.stride_length_per_sec_
 
         # The SL algorithms provide outputs per second of each WB.
         # We further provide interpolated outputs per stride.

--- a/src/mobgap/utils/df_operations.py
+++ b/src/mobgap/utils/df_operations.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, NamedTuple, Union
 
 import numpy as np
 import pandas as pd
+from tpcp.misc import iter_with_warning_error_context
 from typing_extensions import Literal, Unpack
 
 
@@ -364,47 +365,53 @@ def apply_transformations(  # noqa: C901, PLR0912
     """
     transformation_results = []
     column_names = []
-    for transformation in transformations:
-        if getattr(transformation, "_TAG", None) == "CustomOperation":
-            identifier = transformation.identifier
-            functions = [transformation.function]
-            if isinstance(transformation.column_name, list):
-                col_names = transformation.column_name
+    for make_transformation_context, transformation in iter_with_warning_error_context(transformations):
+        with make_transformation_context("transformation"):
+            if getattr(transformation, "_TAG", None) == "CustomOperation":
+                identifier = transformation.identifier
+                functions = [transformation.function]
+                if isinstance(transformation.column_name, list):
+                    col_names = transformation.column_name
+                else:
+                    col_names = [transformation.column_name]
             else:
-                col_names = [transformation.column_name]
-        else:
-            identifier, functions = transformation
-            col_names = []
-            if not isinstance(functions, list):
-                functions = [functions]
-            for fct in functions:
-                try:
-                    fct_name = fct.__name__
-                except AttributeError as e:
-                    raise ValueError(
-                        f"Transformation function {fct} for identifier {identifier} does not have a "
-                        "`__name__`-Attribute. "
-                        "Please use a named function or assign a name."
-                    ) from e
-                col_names.append((identifier, fct_name))
+                identifier, functions = transformation
+                col_names = []
+                if not isinstance(functions, list):
+                    functions = [functions]
+                for fct in functions:
+                    try:
+                        fct_name = fct.__name__
+                    except AttributeError as e:
+                        raise ValueError(
+                            f"Transformation function {fct} for identifier {identifier} does not have a "
+                            "`__name__`-Attribute. "
+                            "Please use a named function or assign a name."
+                        ) from e
+                    col_names.append((identifier, fct_name))
 
-        for fct, col_name in zip(functions, col_names):
-            try:
-                data = _get_data_from_identifier(df, identifier, num_levels=None)
-            except MissingDataColumnsError as e:
-                if missing_columns == "raise":
-                    raise
-                if missing_columns == "warn":
-                    warnings.warn(str(e), stacklevel=1)
-                continue
-            result = fct(data)
-            if isinstance(result, tuple):
-                assert len(result) == len(col_name)
-                transformation_results.extend(result)
-                column_names.extend(col_name)
-            else:
-                transformation_results.append(result)
-                column_names.append(col_name)
+            for make_function_context, (fct, col_name) in iter_with_warning_error_context(zip(functions, col_names)):
+                function_name = getattr(fct, "__name__", type(fct).__name__)
+                with make_function_context(
+                    "transformation_function",
+                    {"identifier": identifier, "function": function_name, "column_name": col_name},
+                ):
+                    try:
+                        data = _get_data_from_identifier(df, identifier, num_levels=None)
+                    except MissingDataColumnsError as e:
+                        if missing_columns == "raise":
+                            raise
+                        if missing_columns == "warn":
+                            warnings.warn(str(e), stacklevel=1)
+                        continue
+                    result = fct(data)
+                    if isinstance(result, tuple):
+                        assert len(result) == len(col_name)
+                        transformation_results.extend(result)
+                        column_names.extend(col_name)
+                    else:
+                        transformation_results.append(result)
+                        column_names.append(col_name)
 
     # combine results
     try:
@@ -505,18 +512,19 @@ def apply_aggregations(
 
     # apply built-in aggregations
     agg_aggregation_results = []
-    for key, aggregation in agg_aggregations.items():
-        try:
-            aggregation_result = df.agg({key: aggregation})
-            agg_aggregation_results.append(
-                aggregation_result.stack(level=np.arange(df.columns.nlevels).tolist(), future_stack=True)
-            )
-        except KeyError as e:
-            if missing_columns == "raise":
-                raise MissingDataColumnsError(key) from e
-            if missing_columns == "warn":
-                warnings.warn(str(MissingDataColumnsError(key)), UserWarning, stacklevel=1)
-            continue
+    for make_context, (key, aggregation) in iter_with_warning_error_context(agg_aggregations.items()):
+        with make_context("aggregation", {"identifier": key}):
+            try:
+                aggregation_result = df.agg({key: aggregation})
+                agg_aggregation_results.append(
+                    aggregation_result.stack(level=np.arange(df.columns.nlevels).tolist(), future_stack=True)
+                )
+            except KeyError as e:
+                if missing_columns == "raise":
+                    raise MissingDataColumnsError(key) from e
+                if missing_columns == "warn":
+                    warnings.warn(str(MissingDataColumnsError(key)), UserWarning, stacklevel=1)
+                continue
     agg_aggregation_results = pd.concat(agg_aggregation_results) if agg_aggregation_results else pd.Series()
 
     manual_aggregation_results = _apply_manual_aggregations(df, manual_aggregations, missing_columns)
@@ -601,37 +609,42 @@ def _apply_manual_aggregations(  # noqa: C901
 ) -> pd.Series:
     # apply manual aggregations
     manual_aggregation_results = []
-    for agg in manual_aggregations:
+    for make_context, agg in iter_with_warning_error_context(manual_aggregations):
         agg_function = agg.function
+        function_name = getattr(agg_function, "__name__", type(agg_function).__name__)
+        with make_context(
+            "aggregation",
+            {"identifier": agg.identifier, "function": function_name, "column_name": agg.column_name},
+        ):
+            try:
+                data = _get_data_from_identifier(df, agg.identifier, num_levels=None)
+            except MissingDataColumnsError as e:
+                if missing_columns == "raise":
+                    raise
+                if missing_columns == "warn":
+                    warnings.warn(str(e), UserWarning, stacklevel=1)
+                continue
 
-        try:
-            data = _get_data_from_identifier(df, agg.identifier, num_levels=None)
-        except MissingDataColumnsError as e:
-            if missing_columns == "raise":
-                raise
-            if missing_columns == "warn":
-                warnings.warn(str(e), UserWarning, stacklevel=1)
-            continue
-
-        result = agg_function(data)
-        if not agg.column_name:
-            raise ValueError(
-                "Custom aggregations always need to specify a column name that includes the metric."
-                "E.g. ('icc', 'speed_error') for the ICC of the speed error."
-            )
-        if isinstance(agg.column_name, list):
-            # We need to spread the results over multiple columns
-            result = result if isinstance(result, tuple) else (result,)
-            if not len(agg.column_name) == len(result):
+            result = agg_function(data)
+            if not agg.column_name:
                 raise ValueError(
-                    "The number of column names provided does not match the number of results returned by the function."
+                    "Custom aggregations always need to specify a column name that includes the metric."
+                    "E.g. ('icc', 'speed_error') for the ICC of the speed error."
                 )
-            for col_name, res in zip(agg.column_name, result):
-                manual_aggregation_results.append(pd.Series([res], index=_construct_index_from_col_name(col_name)))
-        else:
-            manual_aggregation_results.append(
-                pd.Series([result], index=_construct_index_from_col_name(agg.column_name))
-            )
+            if isinstance(agg.column_name, list):
+                # We need to spread the results over multiple columns
+                result = result if isinstance(result, tuple) else (result,)
+                if not len(agg.column_name) == len(result):
+                    raise ValueError(
+                        "The number of column names provided does not match the number of results returned by the "
+                        "function."
+                    )
+                for col_name, res in zip(agg.column_name, result):
+                    manual_aggregation_results.append(pd.Series([res], index=_construct_index_from_col_name(col_name)))
+            else:
+                manual_aggregation_results.append(
+                    pd.Series([result], index=_construct_index_from_col_name(agg.column_name))
+                )
     if len(manual_aggregation_results) == 0:
         return pd.Series()
     try:

--- a/src/mobgap/wba/_stride_selection.py
+++ b/src/mobgap/wba/_stride_selection.py
@@ -4,7 +4,7 @@ from typing import Final, Literal, Optional
 
 import pandas as pd
 from tpcp import Algorithm, cf
-from tpcp.misc import set_defaults
+from tpcp.misc import iter_with_warning_error_context, set_defaults
 from typing_extensions import Self
 
 from mobgap.wba._interval_criteria import (
@@ -140,9 +140,12 @@ class StrideSelection(Algorithm):
             The instance itself with the result parameters set.
         """
         # TODO: Add better checking for compound fields dtype
-        for _, rule in self.rules or []:
-            if not isinstance(rule, BaseIntervalCriteria):
-                raise TypeError("All rules must be instances of `IntervalSummaryCriteria` or one of its child classes.")
+        for make_context, (name, rule) in iter_with_warning_error_context(self.rules or []):
+            with make_context("stride_selection_rule", {"name": name}):
+                if not isinstance(rule, BaseIntervalCriteria):
+                    raise TypeError(
+                        "All rules must be instances of `IntervalSummaryCriteria` or one of its child classes."
+                    )
 
         self.stride_list = stride_list
         self.sampling_rate_hz = sampling_rate_hz
@@ -156,23 +159,24 @@ class StrideSelection(Algorithm):
         stride_list_cols = set(stride_list.columns)
 
         rule_results = {}
-        for name, rule in rules_as_dict.items():
-            compatible = set(rule.requires_columns()).issubset(stride_list_cols)
-            if not compatible:
-                if self.incompatible_rules == "raise":
-                    raise ValueError(
-                        f"Rule {name} requires columns {rule.requires_columns()} which are not present in the stride "
-                        "list."
-                    )
-                if self.incompatible_rules == "warn":
-                    warnings.warn(
-                        f"Rule {name} requires columns {rule.requires_columns()} which are not present in the "
-                        "stride list. "
-                        "Skipping rule.",
-                        stacklevel=1,
-                    )
-                continue
-            rule_results[name] = rule.check_multiple(stride_list, sampling_rate_hz=sampling_rate_hz)
+        for make_context, (name, rule) in iter_with_warning_error_context(rules_as_dict.items()):
+            with make_context("stride_selection_rule", {"name": name}):
+                compatible = set(rule.requires_columns()).issubset(stride_list_cols)
+                if not compatible:
+                    if self.incompatible_rules == "raise":
+                        raise ValueError(
+                            f"Rule {name} requires columns {rule.requires_columns()} which are not present in the "
+                            "stride list."
+                        )
+                    if self.incompatible_rules == "warn":
+                        warnings.warn(
+                            f"Rule {name} requires columns {rule.requires_columns()} which are not present in the "
+                            "stride list. "
+                            "Skipping rule.",
+                            stacklevel=1,
+                        )
+                    continue
+                rule_results[name] = rule.check_multiple(stride_list, sampling_rate_hz=sampling_rate_hz)
 
         if len(rule_results) == 0:
             self._exclusion_reasons = pd.DataFrame(columns=["rule_name", "rule_obj"]).reindex(stride_list.index)

--- a/src/mobgap/wba/_wb_assembly.py
+++ b/src/mobgap/wba/_wb_assembly.py
@@ -7,7 +7,7 @@ from typing import Final, Optional
 import numpy as np
 import pandas as pd
 from tpcp import Algorithm, cf
-from tpcp.misc import set_defaults
+from tpcp.misc import iter_with_warning_error_context, set_defaults
 from typing_extensions import Self
 
 from mobgap.wba._wb_criteria import MaxBreakCriteria, NStridesCriteria
@@ -220,9 +220,10 @@ class WbAssembly(Algorithm):
             The instance itself with the result parameters set.
         """
         # TODO: Add better checks for correct type of compound rule field
-        for _, rule in self.rules or []:
-            if not isinstance(rule, BaseWbCriteria):
-                raise TypeError("All rules must be instances of `WBCriteria` or one of its child classes.")
+        for make_context, (name, rule) in iter_with_warning_error_context(self.rules or []):
+            with make_context("walking_bout_rule", {"name": name}):
+                if not isinstance(rule, BaseWbCriteria):
+                    raise TypeError("All rules must be instances of `WBCriteria` or one of its child classes.")
 
         self.filtered_stride_list = filtered_stride_list
         self.raw_initial_contacts = raw_initial_contacts
@@ -431,21 +432,30 @@ class WbAssembly(Algorithm):
         tmp_start = -1
         tmp_end = np.inf
         tmp_restart_at = np.inf
-        for rule_name, rule in self.rules or []:
-            start, end, restart_at = rule.check_wb_start_end(
-                stride_list,
-                original_start=original_start,
-                current_start=current_start,
-                current_end=current_end,
-                sampling_rate_hz=self.sampling_rate_hz,
-            )
-            if start is not None and start > tmp_start:
-                tmp_start = start
-                start_delay_rule = (rule_name, rule)
-            if end is not None and end < tmp_end:
-                tmp_end = end
-                tmp_restart_at = restart_at
-                termination_rule = (rule_name, rule)
+        for make_context, (rule_name, rule) in iter_with_warning_error_context(self.rules or []):
+            with make_context(
+                "walking_bout_rule",
+                {
+                    "name": rule_name,
+                    "original_start": original_start,
+                    "current_start": current_start,
+                    "current_end": current_end,
+                },
+            ):
+                start, end, restart_at = rule.check_wb_start_end(
+                    stride_list,
+                    original_start=original_start,
+                    current_start=current_start,
+                    current_end=current_end,
+                    sampling_rate_hz=self.sampling_rate_hz,
+                )
+                if start is not None and start > tmp_start:
+                    tmp_start = start
+                    start_delay_rule = (rule_name, rule)
+                if end is not None and end < tmp_end:
+                    tmp_end = end
+                    tmp_restart_at = restart_at
+                    termination_rule = (rule_name, rule)
         return tmp_start, tmp_end, tmp_restart_at, start_delay_rule, termination_rule
 
     def _apply_inclusion_rules(
@@ -458,12 +468,14 @@ class WbAssembly(Algorithm):
         wb_list = {}
         removed_wb_list = {}
         exclusion_reasons = {}
-        for wb_id, stride_list in preliminary_wb_list.items():
-            for rule_name, rule in self.rules or []:
-                if not rule.check_include(stride_list, sampling_rate_hz=self.sampling_rate_hz):
-                    removed_wb_list[wb_id] = stride_list
-                    exclusion_reasons[wb_id] = (rule_name, rule)
-                    break
-            else:
-                wb_list[wb_id] = stride_list
+        for make_wb_context, (wb_id, stride_list) in iter_with_warning_error_context(preliminary_wb_list.items()):
+            with make_wb_context("walking_bout", {"wb_id": wb_id}):
+                for make_rule_context, (rule_name, rule) in iter_with_warning_error_context(self.rules or []):
+                    with make_rule_context("walking_bout_rule", {"name": rule_name}):
+                        if not rule.check_include(stride_list, sampling_rate_hz=self.sampling_rate_hz):
+                            removed_wb_list[wb_id] = stride_list
+                            exclusion_reasons[wb_id] = (rule_name, rule)
+                            break
+                else:
+                    wb_list[wb_id] = stride_list
         return wb_list, removed_wb_list, exclusion_reasons

--- a/tests/test_revalidation/test_gsd_misorientation_dataset.py
+++ b/tests/test_revalidation/test_gsd_misorientation_dataset.py
@@ -55,7 +55,7 @@ def _minimal_reference() -> ReferenceData:
 
 
 def test_misoriented_dataset_extends_index_with_orientation() -> None:
-    base_dataset = ReferenceGaitDatasetFromData(
+    wrapped_dataset = ReferenceGaitDatasetFromData(
         {("p1", "r1"): {"LowerBack": pd.DataFrame(index=range(3))}},
         100.0,
         {("p1", "r1"): {"cohort": "HA", "height_m": 1.7, "sensor_height_m": 1.0}},
@@ -65,10 +65,11 @@ def test_misoriented_dataset_extends_index_with_orientation() -> None:
     )
 
     dataset = MisorientedDataset(
-        base_dataset,
+        wrapped_dataset=wrapped_dataset,
         orientations=["identity", "pa_normal__rot_pa_180"],
     )
 
+    assert dataset.wrapped_dataset is wrapped_dataset
     assert list(dataset.index.columns) == ["participant_id", "recording", "orientation"]
     assert dataset.index.to_dict("records") == [
         {"participant_id": "p1", "recording": "r1", "orientation": "identity"},
@@ -78,9 +79,36 @@ def test_misoriented_dataset_extends_index_with_orientation() -> None:
     datapoint = dataset.get_subset(participant_id="p1", recording="r1", orientation="identity")
     pd.testing.assert_frame_equal(
         datapoint.reference_parameters_.wb_list,
-        base_dataset.reference_parameters_.wb_list,
+        wrapped_dataset.reference_parameters_.wb_list,
     )
     assert datapoint.reference_sampling_rate_hz_ == 100.0
+
+
+def test_misoriented_dataset_preserves_wrapped_grouping() -> None:
+    wrapped_dataset = ReferenceGaitDatasetFromData(
+        {
+            ("p1", "r1"): {"LowerBack": pd.DataFrame(index=range(3))},
+            ("p1", "r2"): {"LowerBack": pd.DataFrame(index=range(3))},
+            ("p2", "r1"): {"LowerBack": pd.DataFrame(index=range(3))},
+        },
+        100.0,
+        index_cols=["participant_id", "recording"],
+        groupby_cols="participant_id",
+        reference_parameters=_minimal_reference(),
+    )
+
+    dataset = MisorientedDataset(
+        wrapped_dataset=wrapped_dataset,
+        orientations=["identity", "pa_normal__rot_pa_180"],
+    )
+
+    assert len(dataset) == 4
+    assert dataset.groupby_cols == ["participant_id", "orientation"]
+    assert dataset[0].index.to_dict("records") == [
+        {"participant_id": "p1", "recording": "r1", "orientation": "identity"},
+        {"participant_id": "p1", "recording": "r2", "orientation": "identity"},
+    ]
+    assert dataset[0].orientation_label == "identity"
 
 
 def test_misoriented_dataset_preserves_body_frame_data() -> None:
@@ -88,7 +116,7 @@ def test_misoriented_dataset_preserves_body_frame_data() -> None:
         [[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]],
         columns=BF_SENSOR_COLS,
     )
-    base_dataset = ReferenceGaitDatasetFromData(
+    wrapped_dataset = ReferenceGaitDatasetFromData(
         {"p1": {"LowerBack": body_frame_data}},
         100.0,
         {"p1": {"cohort": "HA", "height_m": 1.7, "sensor_height_m": 1.0}},
@@ -98,7 +126,7 @@ def test_misoriented_dataset_preserves_body_frame_data() -> None:
     )
 
     datapoint = MisorientedDataset(
-        base_dataset,
+        wrapped_dataset=wrapped_dataset,
         orientations=["pa_normal__rot_pa_180"],
     )[0]
 
@@ -114,7 +142,7 @@ def test_misoriented_dataset_preserves_sensor_frame_data() -> None:
         [[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]],
         columns=SF_SENSOR_COLS,
     )
-    base_dataset = ReferenceGaitDatasetFromData(
+    wrapped_dataset = ReferenceGaitDatasetFromData(
         {"p1": {"LowerBack": sensor_frame_data}},
         100.0,
         {"p1": {"cohort": "HA", "height_m": 1.7, "sensor_height_m": 1.0}},
@@ -124,7 +152,7 @@ def test_misoriented_dataset_preserves_sensor_frame_data() -> None:
     )
 
     datapoint = MisorientedDataset(
-        base_dataset,
+        wrapped_dataset=wrapped_dataset,
         orientations=["pa_normal__rot_pa_180"],
     )[0]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2102,7 +2102,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.11.2" },
     { name = "seaborn", specifier = ">=0.12.0" },
     { name = "statsmodels", specifier = ">=0.14.3" },
-    { name = "tpcp", specifier = ">=2.2.1" },
+    { name = "tpcp", specifier = ">=2.3.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -4252,7 +4252,7 @@ wheels = [
 
 [[package]]
 name = "tpcp"
-version = "2.2.1"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
@@ -4267,9 +4267,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/14/309f27fd07f031fdbc04a1f1600316a7e24cf33153df1d9922c92a315ad3/tpcp-2.2.1.tar.gz", hash = "sha256:b7b0ff724891ad8674ae18516b18ac0beee6afaf9bd22aff00c1d1e379da3d91", size = 94168, upload-time = "2026-06-15T09:29:25.41Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/55/52d890dc94a8955a560f99747d78179a2d09147fc7e603536c5b00f86fc0/tpcp-2.3.0.tar.gz", hash = "sha256:5c930f0392fdca4ac9a9bf30cf90ee3913beae73bcc0fbe436e325b5d03f7d78", size = 105029, upload-time = "2026-07-22T13:51:33.827Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/52/4b6ed1f3362468feccc3bb2e7b921354e4218007d73c0878d7fce783749b/tpcp-2.2.1-py3-none-any.whl", hash = "sha256:59b5498344076916aa9d4c89c67f5230d5d1f9de62d2430933449e99de39cf37", size = 111800, upload-time = "2026-06-15T09:29:26.728Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/69/d03d4a8df9c3503a2c80646394fdc3f4fe6cb889c2f6ad518db97d2224eb/tpcp-2.3.0-py3-none-any.whl", hash = "sha256:820d2f5a0c71fc1c17cb0f4c15433bd6d81454a0615046f049b006cc43b9473c", size = 123466, upload-time = "2026-07-22T13:51:32.69Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- require and lock tpcp 2.3.0, with migration guidance
- use tpcp 2.3 warning/error contexts throughout mobgap's iterative processing
- preserve context through revalidation and dataset file-processing workers with `tpcp.parallel`
- adopt `DatasetWrapperMixin` for `MisorientedDataset`, preserve wrapped grouping, and use tpcp's canonical `wrapped_dataset` constructor/attribute
- record the repository compatibility policy and minimal RoboRev guidance

## Diagnostic context coverage

Warnings and exceptions now identify the applicable:

- selected pipeline and cohort
- gait sequence or walking bout, including start/end boundaries
- refined gait sequence or walking bout
- simulated orientation
- transformer-chain stage
- stride-selection and walking-bout rule
- DMO aggregation filter
- custom transformation or aggregation callback
- revalidation pipeline and measurement condition
- wear-time or MATLAB input file

Contexts are nested where useful and delayed tasks capture them before worker dispatch. Task creation remains lazy. The simple pipeline-pair overlap check intentionally remains an ordinary loop without diagnostic context.

## Compatibility and migration

- environments pinned to an older tpcp must upgrade to 2.3.0
- warning text and exception notes may now include structured fold, parameter, datapoint, pipeline, region, callback, rule, and input-file context
- `MisorientedDataset` intentionally renames its `base_dataset` constructor argument and attribute to `wrapped_dataset`; this narrow breaking change was explicitly approved by the maintainer and has no compatibility alias
- `MisorientedDataset` now preserves the grouping of its wrapped dataset; callers intentionally needing the previous row-level behavior can pass all source index columns plus orientation through `groupby_cols`
- the grouping correction is an explicitly approved bug fix
- result values, exception types, warnings, other public APIs, and persisted formats are unchanged

## tpcp 2.0–2.3 feature audit

Adopted here:

- tpcp 2.3 `DatasetWrapperMixin`
- tpcp 2.3 context-aware `Parallel` and `delayed`
- tpcp 2.3 `warning_error_context`, `iter_with_warning_error_context`, and typed-iterator contexts

Already used or automatically inherited:

- tpcp 2.0 `no_agg` and `final_aggregator`
- tpcp 2.0 dataset equality
- tpcp 2.1 stricter parameter validation and `DatasetSplitter` improvements
- tpcp 2.1.1–2.2.1 compatibility, scorer multiprocessing, and snapshot fixes

Consider separately because they could affect public or scientific behavior:

- `train_dataset_transform` for fold-local augmentation or intentional smoke-test subsampling
- tpcp's predefined/pretrained parameter recipe, where mobgap already has its own public presets
- tpcp agent-skill installation, which is optional developer tooling
- generic float aggregators, because current mobgap final aggregators are domain-specific

## Verification

- `uv run --no-sync poe test_ci_no_coverage -q` — 1283 passed, 37 skipped
- `uv run --no-sync poe ci_check`
- `uv build`
- focused wrapper and official-pipeline tests
- tpcp 2.3, canonical `wrapped_dataset`, and one-/two-process context propagation smoke checks
- all per-commit and whole-stack RoboRev reviews closed; the compatibility-alias finding was overruled based on explicit maintainer approval
